### PR TITLE
TextField 컴포넌트 추가 구현

### DIFF
--- a/src/app/components/common/Text/BaseText.tsx
+++ b/src/app/components/common/Text/BaseText.tsx
@@ -57,12 +57,20 @@ const textStyles = cva('', {
       false: 'text-nowrap',
     },
     color: {
+      // Semantic
       info: 'text-[--color-text-info]',
       success: 'text-[--color-text-success]',
       warning: 'text-[--color-text-warning]',
       error: 'text-[--color-text-danger]',
+      // Brand
       primary: 'text-[--color-text-brand]',
-      secondary: '',
+      // Label
+      normal: 'text-cool-neutral-99',
+      strong: 'text-common-100',
+      neutral: 'text-cool-neutral-90A',
+      alternative: 'text-cool-neutral-80A',
+      assistive: 'text-[#AEB0B647]',
+      disabled: 'text-cool-neutral-70A',
     },
   },
   // 스타일 처리 조건

--- a/src/app/components/common/TextField/FormHelperText.tsx
+++ b/src/app/components/common/TextField/FormHelperText.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { cx } from 'class-variance-authority';
 
 import ErrorSVG from '@public/icons/error.svg';
@@ -25,7 +23,7 @@ export default function FormHelperText<T extends React.ElementType = 'p'>({
       variant="label-2"
       weight="regular"
       align={align}
-      {...(error ? { color: 'error' } : {})}
+      {...(error ? { color: 'error' } : { color: 'alternative' })}
       {...rest}
     >
       {error && (

--- a/src/app/components/common/TextField/index.tsx
+++ b/src/app/components/common/TextField/index.tsx
@@ -44,8 +44,7 @@ const inputStyles = cva(
   {
     variants: {
       variant: {
-        filled: '',
-        outlined: ['border border-[#70737C52]'],
+        outlined: ['border border-[#70737C52]', 'focus:border-transparent'],
       },
       error: {
         true: 'text-[--color-text-danger]',

--- a/src/app/components/common/TextField/index.tsx
+++ b/src/app/components/common/TextField/index.tsx
@@ -86,7 +86,7 @@ type TextFieldComponent = <T extends React.ElementType = 'input'>(
   },
 ) => React.ReactNode | null;
 
-export const TextField: TextFieldComponent = forwardRef(function TextField<
+const TextField: TextFieldComponent = forwardRef(function TextField<
   T extends React.ElementType,
 >(
   {
@@ -134,3 +134,5 @@ export const TextField: TextFieldComponent = forwardRef(function TextField<
     </div>
   );
 });
+
+export default TextField;


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #20 

### ⚙️ Changes
<!-- 변경한 내용에 대한 간단한 요약을 설명합니다. -->

- TextField 컴포넌트 추가 구현
- Text 컴포넌트 [피그마 Label 이하 컬러](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=1-3024&t=BTqv3O8mGCpdx0Df-4) 추가
