### PR TITLE
Button 컴포넌트 추가 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,7 +18,12 @@ const config: StorybookConfig = {
     check: false,
     checkOptions: {},
     reactDocgen: 'react-docgen-typescript',
-    reactDocgenTypescriptOptions: {}, // Available only when reactDocgen is set to 'react-docgen-typescript'
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      // 👇 Default prop filter, which excludes props from node_modules
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
+    },
     skipCompiler: true,
   },
 };

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -26,5 +26,23 @@ const config: StorybookConfig = {
     },
     skipCompiler: true,
   },
+  webpackFinal: async (config) => {
+    config.module = config.module || {};
+    config.module.rules = config.module.rules || [];
+
+    config.module.rules
+      .filter((rule) => rule?.['test']?.test('.svg'))
+      .forEach((rule) => {
+        if (rule) rule['exclude'] = /\.svg$/;
+      });
+
+    // Configure .svg files to be loaded with @svgr/webpack
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    });
+
+    return config;
+  },
 };
 export default config;

--- a/src/app/components/common/Button/Button.stories.tsx
+++ b/src/app/components/common/Button/Button.stories.tsx
@@ -38,9 +38,6 @@ const meta = {
     disabled: {
       control: 'boolean',
     },
-    grouped: {
-      control: 'boolean',
-    },
   },
 } satisfies Meta<typeof Button>;
 

--- a/src/app/components/common/Button/Button.stories.tsx
+++ b/src/app/components/common/Button/Button.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Button from '.';
+
+const meta = {
+  title: 'Components/Common/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: false,
+    },
+    variant: {
+      table: {
+        defaultValue: {
+          summary: '"primary"',
+        },
+      },
+      options: ['primary', 'secondary', 'ghost'],
+      control: {
+        type: 'inline-radio',
+      },
+    },
+    size: {
+      table: {
+        defaultValue: {
+          summary: '"medium"',
+        },
+      },
+      options: ['small', 'medium', 'large'],
+      control: {
+        type: 'inline-radio',
+      },
+    },
+    loading: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    grouped: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const PrimaryButton: Story = {
+  args: {
+    variant: 'primary',
+    size: 'medium',
+    children: 'Primary Button',
+  },
+};
+
+export const SecondaryButton: Story = {
+  args: {
+    variant: 'secondary',
+    size: 'medium',
+    children: 'Secondary Button',
+  },
+};
+
+export const GhostButton: Story = {
+  args: {
+    variant: 'ghost',
+    size: 'medium',
+    children: 'Ghost Button',
+  },
+};

--- a/src/app/components/common/Button/index.tsx
+++ b/src/app/components/common/Button/index.tsx
@@ -8,7 +8,7 @@ import Icon from '@components/common/Icon';
 
 import cn from '@utils/cn';
 
-const buttonStyles = cva('body-2-semibold', {
+const buttonStyles = cva('body-2-semibold h-[55px]', {
   variants: {
     variant: {
       primary: [
@@ -19,16 +19,19 @@ const buttonStyles = cva('body-2-semibold', {
       ghost: ['bg-transparent', 'text-cool-neutral-99'],
     },
     size: {
-      small: ['w-[164px]', 'h-[44px]', 'rounded-8', 'px-12', 'py-[10px]'],
-      medium: ['w-[248px]', 'h-[55px]', 'rounded-12', 'px-16', 'py-[10px]'],
-      large: ['w-[335px]', 'h-[55px]', 'rounded-12', 'px-16', 'py-[10px]'],
+      small: [
+        'label-1-medium',
+        'w-[128px]',
+        'h-[44px]',
+        'rounded-8',
+        'px-12',
+        'py-[10px]',
+      ],
+      medium: ['w-[164px]', 'rounded-12', 'px-16', 'py-[10px]'],
+      large: ['w-[335px]', 'rounded-12', 'px-16', 'py-[10px]'],
     },
     disabled: {
       true: 'text-cool-neutral-70A',
-    },
-    // ! small & grouped => 사이즈 변경 필요
-    grouped: {
-      true: '',
     },
   },
   compoundVariants: [
@@ -36,11 +39,6 @@ const buttonStyles = cva('body-2-semibold', {
       variant: ['primary', 'secondary'],
       disabled: true,
       className: ['bg-cool-neutral-22'],
-    },
-    {
-      size: 'small',
-      grouped: true,
-      className: ['w-[128px]', 'label-1-medium'],
     },
   ],
   defaultVariants: {
@@ -57,17 +55,14 @@ export type ButtonProps = React.PropsWithChildren<
   React.ComponentPropsWithRef<'button'>;
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { children, className, variant, size, grouped, loading, disabled, ...rest },
+  { children, className, variant, size, loading, disabled, ...rest },
   ref,
 ) {
   return (
     <button
       ref={ref}
       disabled={disabled || loading}
-      className={cn(
-        buttonStyles({ variant, size, grouped, disabled }),
-        className,
-      )}
+      className={cn(buttonStyles({ variant, size, disabled }), className)}
       {...rest}
     >
       {!loading && children}

--- a/src/app/components/common/Button/index.tsx
+++ b/src/app/components/common/Button/index.tsx
@@ -56,30 +56,28 @@ export type ButtonProps = React.PropsWithChildren<
 > &
   React.ComponentPropsWithRef<'button'>;
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button(
-    { children, className, variant, size, grouped, loading, disabled, ...rest },
-    ref,
-  ) {
-    return (
-      <button
-        ref={ref}
-        disabled={disabled || loading}
-        className={cn(
-          buttonStyles({ variant, size, grouped, disabled }),
-          className,
-        )}
-        {...rest}
-      >
-        {!loading && children}
-        {loading && (
-          <Icon size={24}>
-            <SpinSVG />
-          </Icon>
-        )}
-      </button>
-    );
-  },
-);
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { children, className, variant, size, grouped, loading, disabled, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      disabled={disabled || loading}
+      className={cn(
+        buttonStyles({ variant, size, grouped, disabled }),
+        className,
+      )}
+      {...rest}
+    >
+      {!loading && children}
+      {loading && (
+        <Icon size={24}>
+          <SpinSVG />
+        </Icon>
+      )}
+    </button>
+  );
+});
 
 export default Button;

--- a/src/app/components/common/Button/index.tsx
+++ b/src/app/components/common/Button/index.tsx
@@ -1,0 +1,85 @@
+import { forwardRef } from 'react';
+
+import { cva, VariantProps } from 'class-variance-authority';
+
+import SpinSVG from '@public/icons/spin.svg';
+
+import Icon from '@components/common/Icon';
+
+import cn from '@utils/cn';
+
+const buttonStyles = cva('body-2-semibold', {
+  variants: {
+    variant: {
+      primary: [
+        'bg-[--color-background-button-primary-base]',
+        'text-cool-neutral-10',
+      ],
+      secondary: ['bg-cool-neutral-23', 'text-cool-neutral-90A'],
+      ghost: ['bg-transparent', 'text-cool-neutral-99'],
+    },
+    size: {
+      small: ['w-[164px]', 'h-[44px]', 'rounded-8', 'px-12', 'py-[10px]'],
+      medium: ['w-[248px]', 'h-[55px]', 'rounded-12', 'px-16', 'py-[10px]'],
+      large: ['w-[335px]', 'h-[55px]', 'rounded-12', 'px-16', 'py-[10px]'],
+    },
+    disabled: {
+      true: 'text-cool-neutral-70A',
+    },
+    // ! small & grouped => 사이즈 변경 필요
+    grouped: {
+      true: '',
+    },
+  },
+  compoundVariants: [
+    {
+      variant: ['primary', 'secondary'],
+      disabled: true,
+      className: ['bg-cool-neutral-22'],
+    },
+    {
+      size: 'small',
+      grouped: true,
+      className: ['w-[128px]', 'label-1-medium'],
+    },
+  ],
+  defaultVariants: {
+    variant: 'primary',
+    size: 'medium',
+  },
+});
+
+export type ButtonProps = React.PropsWithChildren<
+  VariantProps<typeof buttonStyles> & {
+    loading?: boolean;
+  }
+> &
+  React.ComponentPropsWithRef<'button'>;
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    { children, className, variant, size, grouped, loading, disabled, ...rest },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={cn(
+          buttonStyles({ variant, size, grouped, disabled }),
+          className,
+        )}
+        {...rest}
+      >
+        {!loading && children}
+        {loading && (
+          <Icon size={24}>
+            <SpinSVG />
+          </Icon>
+        )}
+      </button>
+    );
+  },
+);
+
+export default Button;


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #25 
- 관련 Figma : [디자인파일](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=287-3976&t=ENeHUKq6bC7DqCci-4)

### ⚙️ Changes
<!-- 변경한 내용에 대한 간단한 요약을 설명합니다. -->
> 기존에 추가되어있던 `loading`과 `disabled`의 경우 동일하게 가져갔습니다. (spinner 아이콘 포함)

- Button 컴포넌트 **사이즈별** 베리에이션 추가하였습니다. (`small`, `medium`, `large`)
- Button 컴포넌트 **타입별** 베리에이션 추가하였습니다. (`primary`, `secondary`, `ghost`)
 
추가적으로 사이즈별 피그마 참고 링크 남겨놓겠습니다!
모달 내부에서 사용되는 버튼은 `size="small"`으로 사용하시고,
모달 내부에서 [부분적으로 width가 다른 부분](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=436-6337&t=ENeHUKq6bC7DqCci-4)들은 width만 따로 적용하여 사용하면 될 것 같습니다~!

- [small 버튼 참고](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=287-2077&t=ENeHUKq6bC7DqCci-4)
- [medium 버튼 참고](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=287-3817&t=ENeHUKq6bC7DqCci-4)
- [large 버튼 참고](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=287-1671&t=ENeHUKq6bC7DqCci-4)




