### PR TITLE
사용자 감정 설정 CSS 수정 

### DIFF
--- a/src/app/(route)/(monster)/component/SelectEmotion.tsx
+++ b/src/app/(route)/(monster)/component/SelectEmotion.tsx
@@ -4,6 +4,7 @@ import { ChangeEventHandler, useEffect } from 'react';
 
 import { cva } from 'class-variance-authority';
 
+import FormLabel from '@components/common/FormLabel';
 import FormHelperText from '@components/common/TextField/FormHelperText';
 
 import cn from '@utils/cn';
@@ -11,25 +12,38 @@ import cn from '@utils/cn';
 import useSignUpContext from '../../(auth)/signup/hooks/useSignUpContext';
 import useUserInfoContext from '../../(auth)/signup/hooks/useUserInfoContext';
 
+const EMOTIONS = [
+  ['분노', 'angry'],
+  ['우울', 'depression'],
+];
+
+const gridStyles = cva('grid', {
+  variants: {
+    row: {
+      1: 'grid-rows-1',
+      2: 'grid-rows-2',
+    },
+    column: {
+      1: 'grid-cols-1',
+      2: 'grid-cols-2',
+    },
+  },
+});
+
 const buttonStyle = cva(
-  cn(
-    'w-full bg-[#70737C1F] rounded-20 aspect-[335/160] h-auto heading-1-semibold block text-center',
+  [
+    'w-full h-full rounded-20',
     'flex justify-center items-center',
-  ),
+    // default
+    'bg-[#70737C1F] text-cool-neutral-90A',
+    // :has[:checked]
+    'has-[:checked]:bg-blue-60 has-[:checked]:text-white',
+    // important
+    '!heading-1-semibold',
+  ],
   {
-    variants: {
-      variant: {
-        top: 'mb-8',
-        bottom: 'mt-8',
-      },
-      selected: {
-        true: 'text-white bg-blue-60',
-        false: 'text-cool-neutral-90A',
-      },
-    },
-    defaultVariants: {
-      selected: false,
-    },
+    variants: {},
+    defaultVariants: {},
   },
 );
 
@@ -53,44 +67,33 @@ function SelectEmotion() {
   }, [emotion]);
 
   return (
-    <fieldset className="flex flex-col">
+    <fieldset className="flex h-full w-full flex-col">
       <FormHelperText component="legend" className="mb-12">
         나의 감정
       </FormHelperText>
-
-      <label
-        htmlFor="angry"
-        className={buttonStyle({
-          variant: 'top',
-          selected: emotion === 'angry',
-        })}
+      <div
+        className={cn(
+          gridStyles({
+            row: 2,
+            column: 1,
+          }),
+          'full-height h-full w-full gap-8 pb-[86px]',
+        )}
       >
-        <span>분노</span>
-        <input
-          type="radio"
-          id="angry"
-          name="emotion"
-          className="a11yHidden"
-          onChange={handleChange}
-        />
-      </label>
-
-      <label
-        htmlFor="depressed"
-        className={buttonStyle({
-          variant: 'bottom',
-          selected: emotion === 'depressed',
-        })}
-      >
-        <span>우울</span>
-        <input
-          type="radio"
-          id="depressed"
-          name="emotion"
-          className="a11yHidden"
-          onChange={handleChange}
-        />
-      </label>
+        {EMOTIONS.map(([text, id]) => (
+          <FormLabel key={id} id={id} className={buttonStyle()}>
+            {text}
+            <input
+              type="radio"
+              id={id}
+              name="emotion"
+              className="a11yHidden"
+              onChange={handleChange}
+              checked={emotion === id}
+            />
+          </FormLabel>
+        ))}
+      </div>
     </fieldset>
   );
 }


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #37 

### ⚙️ Changes
- label 태그를 FormLabel으로 변경하였습니다. 
- 감정 버튼 컨테이너 스타일의 용이한 변경을 위하여 `grid`로 변경하였습니다.
- 감정 버튼 추가 시 용이한 확장을 위하여 감정을`EMTIONS` 상수로 분리하고, `map()`을 통해 생성하도록 변경하였습니다.
- selected된 버튼의 스타일 적용을 연산자를 통한 확인을 거치지 않고 `:has` 셀렉터를 통해 CSS단에서 처리하도록 변경하였습니다.
- 이전 혹은 이후 페이지 시 선택이 유지되도록 `checked` 속성을 추가하였습니다. 

