### PR TITLE
로그인 및 회원가입 페이지 미들웨어 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.37.1",
+        "@types/crypto-js": "^4.2.2",
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "crypto-js": "^4.2.0",
         "framer-motion": "^11.2.6",
         "jotai": "^2.8.1",
         "next": "14.2.3",
@@ -6843,6 +6845,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
     "node_modules/@types/detect-port": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.5.tgz",
@@ -9892,6 +9899,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -25055,6 +25067,11 @@
         "@types/node": "*"
       }
     },
+    "@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
     "@types/detect-port": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.5.tgz",
@@ -27440,6 +27457,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "crypto-random-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.37.1",
+    "@types/crypto-js": "^4.2.2",
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
     "framer-motion": "^11.2.6",
     "jotai": "^2.8.1",
     "next": "14.2.3",

--- a/src/app/(route)/(auth)/signup/components/InitialUserState.tsx
+++ b/src/app/(route)/(auth)/signup/components/InitialUserState.tsx
@@ -11,7 +11,7 @@ function InitialUserState({ children }: Props) {
 
   const searchParams = useSearchParams();
   const code = (Number(searchParams.get('code')) as 100 | 101 | 102) || 100;
-  const defaultUserName = searchParams.get('userName') || '';
+  const defaultUserName = searchParams.get('user') || '';
 
   useEffect(() => {
     updater({ payload: { code, nickname: defaultUserName } });

--- a/src/app/(route)/(auth)/signup/components/MakeNickName.tsx
+++ b/src/app/(route)/(auth)/signup/components/MakeNickName.tsx
@@ -47,7 +47,7 @@ function MakeNickName() {
 
   useEffect(() => {
     registerCallback(handleClick);
-  }, []);
+  }, [handleClick]);
 
   return (
     <div className="flex flex-col justify-between">

--- a/src/app/(route)/api/auth/[...auth]/utils/cookie.ts
+++ b/src/app/(route)/api/auth/[...auth]/utils/cookie.ts
@@ -1,0 +1,46 @@
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+import { NextRequest, NextResponse } from 'next/server';
+
+const getCookie = (keys: string[], request: NextRequest) => {
+  const { cookies } = request;
+  const result: Record<(typeof keys)[number], string | undefined> = {};
+
+  keys.forEach((key) => {
+    result[key] = cookies.get(key)?.value || undefined;
+  });
+
+  return { ...result };
+};
+
+const setCookie = (
+  pairs: { key: string; value: string; proteced?: boolean }[],
+  response: NextResponse,
+) => {
+  const { cookies } = response;
+  const cookieOptions: Partial<ResponseCookie> =
+    process.env.NODE_ENV !== 'development'
+      ? {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'lax',
+          path: '/',
+          domain: process.env.NEXT_PUBLIC_DOMAIN_NAME,
+        }
+      : {};
+
+  pairs.forEach(({ key, value, proteced }) => {
+    cookies.set(key, value, proteced ? cookieOptions : {});
+  });
+
+  return response;
+};
+
+const deleteCookie = (keys: string[], response: NextResponse) => {
+  keys.map((cookie) => {
+    return response.cookies.delete(cookie);
+  });
+
+  return response;
+};
+
+export { getCookie, setCookie, deleteCookie };

--- a/src/app/(route)/api/auth/[...auth]/utils/crypto.ts
+++ b/src/app/(route)/api/auth/[...auth]/utils/crypto.ts
@@ -1,30 +1,10 @@
-import crypto from 'crypto';
+import CryptoJS from 'crypto-js';
 
 function encrypt(text: string, password: string) {
-  const salt = crypto.randomBytes(16);
-  const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256');
-  const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
-
-  let encrypted = cipher.update(text, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-
-  // IV와 salt를 암호문과 함께 문자열로 결합
-  const combined = `${salt.toString('hex')}:${iv.toString('hex')}:${encrypted}`;
-
-  return combined;
+  return CryptoJS.AES.encrypt(text, password).toString();
 }
 
-function decrypt(encryptedCombined: string, password: string) {
-  const [saltHex, ivHex, encryptedData] = encryptedCombined.split(':');
-  const salt = Buffer.from(saltHex, 'hex');
-  const iv = Buffer.from(ivHex, 'hex');
-  const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256');
-  const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8');
-  decrypted += decipher.final('utf8');
-
-  return decrypted;
+function decrypt(encrypted: string, password: string) {
+  return CryptoJS.AES.decrypt(encrypted, password).toString(CryptoJS.enc.Utf8);
 }
 export { encrypt, decrypt };

--- a/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
+++ b/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
@@ -1,47 +1,10 @@
-import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { NextResponse } from 'next/server';
 
 import type { TokenResponse } from '@api/schema/token';
 
+import { setCookie } from './cookie';
 import { encrypt } from './crypto';
 import tokenPrefix from './token-prefix';
-
-const setCookie = (
-  response: NextResponse,
-  {
-    secret,
-    accessToken,
-    refreshToken,
-  }: { refreshToken: string; accessToken: string; secret: string },
-) => {
-  const cookies = [
-    {
-      key: tokenPrefix('accessToken'),
-      value: encrypt(accessToken, secret),
-    },
-    {
-      key: tokenPrefix('refreshToken'),
-      value: encrypt(refreshToken, secret),
-    },
-  ];
-
-  cookies.map(({ key, value }) => {
-    const cookieOptions: Partial<ResponseCookie> =
-      process.env.NODE_ENV !== 'development'
-        ? {
-            httpOnly: true,
-            secure: true,
-            sameSite: 'lax',
-            path: '/',
-            domain: process.env.NEXT_PUBLIC_DOMAIN_NAME,
-          }
-        : {};
-
-    return response.cookies.set(key, value, cookieOptions);
-  });
-
-  return response;
-};
 
 const redirectResponse = (
   { code, username, accessToken, refreshToken }: TokenResponse,
@@ -57,7 +20,21 @@ const redirectResponse = (
     { status: 302 },
   );
 
-  return setCookie(response, { accessToken, refreshToken, secret });
+  return setCookie(
+    [
+      {
+        key: tokenPrefix('accessToken'),
+        value: encrypt(accessToken, secret),
+        proteced: true,
+      },
+      {
+        key: tokenPrefix('refreshToken'),
+        value: encrypt(refreshToken, secret),
+        proteced: true,
+      },
+    ],
+    response,
+  );
 };
 
 export { redirectResponse, setCookie };

--- a/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
+++ b/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
@@ -1,7 +1,7 @@
 import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { NextResponse } from 'next/server';
 
-import { type Response as TypeResponse } from '@api/auth/token/get-token';
+import type { TokenResponse } from '@api/schema/token';
 
 import { encrypt } from './crypto';
 import tokenPrefix from './token-prefix';
@@ -44,7 +44,7 @@ const setCookie = (
 };
 
 const redirectResponse = (
-  { code, username, accessToken, refreshToken }: TypeResponse,
+  { code, username, accessToken, refreshToken }: TokenResponse,
   secret: string,
 ) => {
   const destinationUrl =
@@ -56,6 +56,7 @@ const redirectResponse = (
     `${process.env.NEXT_PUBLIC_DOMAIN_NAME}${destinationUrl}`,
     { status: 302 },
   );
+
   return setCookie(response, { accessToken, refreshToken, secret });
 };
 

--- a/src/app/api/auth/nickname.ts
+++ b/src/app/api/auth/nickname.ts
@@ -1,13 +1,13 @@
 import { apiInstance } from '@api/api.config';
 
 const createUserName = async (username: string) => {
-  const path = '/members/my';
+  const path = '/api/v1/members/my';
 
   return apiInstance.post(path, { username });
 };
 
 const modifyUserName = async (username: string) => {
-  const path = '/members/my';
+  const path = '/api/v1/members/my';
 
   return apiInstance.put(path, { username });
 };

--- a/src/app/api/auth/token/get-token.ts
+++ b/src/app/api/auth/token/get-token.ts
@@ -1,22 +1,9 @@
 import ROUTER from '@constant/api.router';
 
 import { apiInstance } from '@api/api.config';
+import type { TokenResponse } from '@api/schema/token';
 
 import type { Providers } from '@type/auth';
-
-export interface Response {
-  memberId: number;
-  accessToken: string;
-  refreshToken: string;
-  username: string;
-  /**
-   * @description
-   * 100 닉네임 설정 false & 몬스터 생성 false
-   * 101 닉네임 설정 true & 몬스터 설정 false
-   * 102 닉네임 설정 true & 몬스터 설정 true
-   */
-  code: 100 | 101 | 102;
-}
 
 type Props = {
   code: string;
@@ -26,7 +13,7 @@ type Props = {
 const requestUserToken = ({ code, provider }: Props) => {
   const path = ROUTER.AUTH.TOKEN[provider];
 
-  return apiInstance.post<Response>(path, { code });
+  return apiInstance.post<TokenResponse>(path, { code });
 };
 
 export default requestUserToken;

--- a/src/app/api/auth/token/refresh-token.ts
+++ b/src/app/api/auth/token/refresh-token.ts
@@ -1,15 +1,10 @@
 import { apiInstance } from '@api/api.config';
-
-interface Response {
-  memberId: number;
-  accessToken: string;
-  refreshToken: string;
-}
+import { TokenResponse } from '@api/schema/token';
 
 const refreshTokenApi = (refreshToken: string) => {
   const path = '/api/v1/members/token/refresh';
 
-  return apiInstance.post<Response>(path, { refreshToken });
+  return apiInstance.post<TokenResponse>(path, { refreshToken });
 };
 
 export default refreshTokenApi;

--- a/src/app/api/schema/token.ts
+++ b/src/app/api/schema/token.ts
@@ -1,0 +1,13 @@
+export interface TokenResponse {
+  memberId: number;
+  accessToken: string;
+  refreshToken: string;
+  username: string;
+  /**
+   * @description
+   * 100 닉네임 설정 false & 몬스터 생성 false
+   * 101 닉네임 설정 true & 몬스터 설정 false
+   * 102 닉네임 설정 true & 몬스터 설정 true
+   */
+  code: 100 | 101 | 102;
+}

--- a/src/app/middlewares/withAuthentication.ts
+++ b/src/app/middlewares/withAuthentication.ts
@@ -1,0 +1,30 @@
+import {
+  type NextFetchEvent,
+  type NextMiddleware,
+  type NextRequest,
+  NextResponse,
+} from 'next/server';
+
+import tokenPrefix from '../(route)/api/auth/[...auth]/utils/token-prefix';
+
+function withAuthentification(middleware: NextMiddleware) {
+  const withAuthList = ['/signup'];
+
+  return async (request: NextRequest, event: NextFetchEvent) => {
+    const { url } = request;
+    const isWithAuthUrl = withAuthList.some((path) => url.includes(path));
+
+    if (!isWithAuthUrl) {
+      return middleware(request, event);
+    }
+
+    const accessToken = request.cookies.get(tokenPrefix('accessToken'));
+    const isLogin = Boolean(accessToken && accessToken.value);
+
+    return isLogin
+      ? middleware(request, event)
+      : NextResponse.redirect(`${process.env.NEXT_PUBLIC_DOMAIN_NAME}/signin`);
+  };
+}
+
+export default withAuthentification;

--- a/src/app/middlewares/withAuthentication.ts
+++ b/src/app/middlewares/withAuthentication.ts
@@ -9,17 +9,29 @@ import tokenPrefix from '../(route)/api/auth/[...auth]/utils/token-prefix';
 
 function withAuthentification(middleware: NextMiddleware) {
   const withAuthList = ['/signup'];
+  const withoutAuthList = ['/signin'];
 
   return async (request: NextRequest, event: NextFetchEvent) => {
-    const { url } = request;
-    const isWithAuthUrl = withAuthList.some((path) => url.includes(path));
+    const url = request.nextUrl.clone();
 
-    if (!isWithAuthUrl) {
+    const { pathname } = url;
+    const isWithAuthUrl = withAuthList.some((path) => pathname.includes(path));
+    const isWithoutAuthUrl = withoutAuthList.some((path) =>
+      pathname.includes(path),
+    );
+
+    if (!isWithAuthUrl && !isWithoutAuthUrl) {
       return middleware(request, event);
     }
 
     const accessToken = request.cookies.get(tokenPrefix('accessToken'));
     const isLogin = Boolean(accessToken && accessToken.value);
+
+    if (isWithoutAuthUrl) {
+      return isLogin
+        ? NextResponse.redirect(`${process.env.NEXT_PUBLIC_DOMAIN_NAME}/`)
+        : NextResponse.next();
+    }
 
     return isLogin
       ? middleware(request, event)

--- a/src/app/middlewares/withSignUpHandle.ts
+++ b/src/app/middlewares/withSignUpHandle.ts
@@ -64,7 +64,11 @@ function withSignUpHandle(middleware: NextMiddleware) {
         (code === 101 && `code=${code}&user=${username}`) ||
         '/';
 
-      const response = NextResponse.rewrite(rewriteUrl);
+      const response =
+        url === rewriteUrl.href
+          ? NextResponse.next()
+          : NextResponse.redirect(rewriteUrl);
+
       return setCookie(
         [
           {

--- a/src/app/middlewares/withSignUpHandle.ts
+++ b/src/app/middlewares/withSignUpHandle.ts
@@ -1,0 +1,71 @@
+import {
+  NextFetchEvent,
+  NextMiddleware,
+  NextRequest,
+  NextResponse,
+} from 'next/server';
+
+import { TokenResponse } from '@api/schema/token';
+
+import { decrypt } from '../(route)/api/auth/[...auth]/utils/crypto';
+import { setCookie } from '../(route)/api/auth/[...auth]/utils/redirect';
+import tokenPrefix from '../(route)/api/auth/[...auth]/utils/token-prefix';
+
+function withSignUpHandle(middleware: NextMiddleware) {
+  return async (request: NextRequest, event: NextFetchEvent) => {
+    const { url } = request;
+
+    if (!url.includes('/signup')) {
+      return middleware(request, event);
+    }
+
+    try {
+      const refreshCookie = request.cookies.get(tokenPrefix('refreshToken'))!;
+      const accessCookie = request.cookies.get(tokenPrefix('accessToken'))!;
+
+      const secret = process.env.AUTH_SECRET;
+      const oldAccessToken = decrypt(accessCookie.value, secret);
+      const oldRefreshToken = decrypt(refreshCookie.value, secret);
+
+      const { accessToken, refreshToken, code, username } = await fetch(
+        `${process.env.NEXT_PUBLIC_API_DOMAIN_NAME}/api/v1/members/token/refresh`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${oldAccessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            refreshToken: oldRefreshToken,
+          }),
+        },
+      ).then((res) => res.json() as Promise<TokenResponse>);
+
+      const rewriteUrl = request.nextUrl.clone();
+      rewriteUrl.search =
+        (code === 100 && `code${code}`) ||
+        (code === 101 && `code=${code}&user=${username}`) ||
+        '/';
+
+      const response = NextResponse.rewrite(rewriteUrl);
+      return setCookie(response, {
+        secret: process.env.AUTH_SECRET,
+        accessToken,
+        refreshToken,
+      });
+    } catch (err) {
+      const respone = NextResponse.redirect(
+        `${process.env.NEXT_PUBLIC_DOMAIN_NAME}/signin`,
+      );
+
+      const cookies = [tokenPrefix('accessToken'), tokenPrefix('refreshToken')];
+      cookies.map((cookie) => {
+        return respone.cookies.delete(cookie);
+      });
+
+      return respone;
+    }
+  };
+}
+
+export default withSignUpHandle;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+import withAuthentification from './app/middlewares/withAuthentication';
+import withSignUpHandle from './app/middlewares/withSignUpHandle';
+
+export default withAuthentification(
+  withSignUpHandle(() => NextResponse.next()),
+);
+
+export const config = {
+  matcher: '/signup',
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,5 +8,5 @@ export default withAuthentification(
 );
 
 export const config = {
-  matcher: '/signup',
+  matcher: ['/signup', '/signin'],
 };


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #24 

### ⚙️ Changes

로그인 및 회원가입 페이지 진입 시, 실행할 미들웨어를 추가하였습니다.
- 미들웨어 로직은 각 역할에 맞게 chaining 될 수 있도록 역할에 따라 HOF 함수로 정의하였습니다. 
- withAuthentication 은 로그인과 관련된 로직을 처리합니다. 
- withSignupVerify 는 회원가입 페이지 진입 시 관련 로직을 처리합니다. 

withAuthentication 함수는 로그인 관련 로직을 처리합니다. 
- withAuthList 는 로그인이 필요한 페이지 경로이며, 해당 페이지로 진입하는 경우 로그인 여부에 따라 비로그인 시, 로그인 페이지로 리디렉션 처리 합니다. 
- withoutAuthList 는 로그인 한 경우 진입이 불가능한 페이지로, 해당 페이지로 진입하는 경우 로그인 여부에 따라 로그인 시, fallback 경로(현재는 '/' 으로 통일)로 이동시킵니다. 
- 로그인 검증이 필요 없는 url 인 경우 전달 받은 middleware 함수를 반환합니다. 

withSignupVerify 는 회원 가입 페이지 진입 시 관련 로직을 처리합니다. 
- 회원이 회원 가입 과정에서 이탈한 후, 다시 회원가입 페이지에 진입 시 적절한 페이지로 이동시키기 위한 로직입니다. 
- 서버로부터 refresh API 를 호출하여 회원의 code 와 username 값을 확인하여, 진입하는 경로와 일치 여부를 확인해 일치하지 않을 경우 redirect 처리 합니다. 
