### PR TITLE
서브 유저 페이지 구현 (Sub_start ~ Sub_clear_flip)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "salepinoff",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/query-core": "^5.40.0",
         "@tanstack/react-query": "^5.37.1",
         "@types/crypto-js": "^4.2.2",
         "@types/lodash": "^4.17.4",
@@ -17,12 +18,14 @@
         "crypto-js": "^4.2.0",
         "framer-motion": "^11.2.6",
         "jotai": "^2.8.1",
+        "jotai-tanstack-query": "^0.8.5",
         "lodash": "^4.17.21",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.3.0",
-        "tailwind-scrollbar-hide": "^1.1.7"
+        "tailwind-scrollbar-hide": "^1.1.7",
+        "wonka": "^6.3.4"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.4.0",
@@ -6600,9 +6603,10 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.38.0.tgz",
-      "integrity": "sha512-QtkoxvFcu52mNpp3+qOo9H265m3rt83Dgbw5WnNyJvr83cegrQ7zT8haHhL4Rul6ZQkeovxyWbXVW9zI0WYx6g==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.40.0.tgz",
+      "integrity": "sha512-eD8K8jsOIq0Z5u/QbvOmfvKKE/XC39jA7yv4hgpl/1SRiU+J8QCIwgM/mEHuunQsL87dcvnHqSVLmf9pD4CiaA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -6648,6 +6652,16 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.39.0",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query/node_modules/@tanstack/query-core": {
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.38.0.tgz",
+      "integrity": "sha512-QtkoxvFcu52mNpp3+qOo9H265m3rt83Dgbw5WnNyJvr83cegrQ7zT8haHhL4Rul6ZQkeovxyWbXVW9zI0WYx6g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -14324,6 +14338,17 @@
         }
       }
     },
+    "node_modules/jotai-tanstack-query": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/jotai-tanstack-query/-/jotai-tanstack-query-0.8.5.tgz",
+      "integrity": "sha512-cFq+1sE7Qkt7Kh9Db2KE8LXdbPiGwCiy8S5YSEnjUDxF59A4XhoXTDJBuPiMIA1dD1/yMsNKr1ADfN5CvscYZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/query-core": "*",
+        "jotai": ">=2.0.0",
+        "wonka": "^6.3.4"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -20384,6 +20409,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wonka": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
+      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==",
+      "license": "MIT"
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -24890,9 +24921,9 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.38.0.tgz",
-      "integrity": "sha512-QtkoxvFcu52mNpp3+qOo9H265m3rt83Dgbw5WnNyJvr83cegrQ7zT8haHhL4Rul6ZQkeovxyWbXVW9zI0WYx6g=="
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.40.0.tgz",
+      "integrity": "sha512-eD8K8jsOIq0Z5u/QbvOmfvKKE/XC39jA7yv4hgpl/1SRiU+J8QCIwgM/mEHuunQsL87dcvnHqSVLmf9pD4CiaA=="
     },
     "@tanstack/query-devtools": {
       "version": "5.37.1",
@@ -24906,6 +24937,13 @@
       "integrity": "sha512-zc0WnyEffyTgG+myLv8cY2tJOUT6jOprCiprpbMqylCaCFipSDUPCYCt2AC+qxgk2CFuqiI/fjb1u5/HhLkrPg==",
       "requires": {
         "@tanstack/query-core": "5.38.0"
+      },
+      "dependencies": {
+        "@tanstack/query-core": {
+          "version": "5.38.0",
+          "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.38.0.tgz",
+          "integrity": "sha512-QtkoxvFcu52mNpp3+qOo9H265m3rt83Dgbw5WnNyJvr83cegrQ7zT8haHhL4Rul6ZQkeovxyWbXVW9zI0WYx6g=="
+        }
       }
     },
     "@tanstack/react-query-devtools": {
@@ -30634,6 +30672,12 @@
       "integrity": "sha512-Gmk5Y3yJL/vN5S0rQ6AaWpXH5Q+HBGHThMHXfylVzXGVuO8YxPRtZf8Y9XYvl+h7ZMQXoHNdFi37vNsJFsiszQ==",
       "requires": {}
     },
+    "jotai-tanstack-query": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/jotai-tanstack-query/-/jotai-tanstack-query-0.8.5.tgz",
+      "integrity": "sha512-cFq+1sE7Qkt7Kh9Db2KE8LXdbPiGwCiy8S5YSEnjUDxF59A4XhoXTDJBuPiMIA1dD1/yMsNKr1ADfN5CvscYZw==",
+      "requires": {}
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -35007,6 +35051,11 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.2"
       }
+    },
+    "wonka": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
+      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg=="
     },
     "word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ]
   },
   "dependencies": {
+    "@tanstack/query-core": "^5.40.0",
     "@tanstack/react-query": "^5.37.1",
     "@types/crypto-js": "^4.2.2",
     "@types/lodash": "^4.17.4",
@@ -28,12 +29,14 @@
     "crypto-js": "^4.2.0",
     "framer-motion": "^11.2.6",
     "jotai": "^2.8.1",
+    "jotai-tanstack-query": "^0.8.5",
     "lodash": "^4.17.21",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.3.0",
-    "tailwind-scrollbar-hide": "^1.1.7"
+    "tailwind-scrollbar-hide": "^1.1.7",
+    "wonka": "^6.3.4"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.4.0",

--- a/src/app/(route)/(monster)/component/CustomizeMonster.tsx
+++ b/src/app/(route)/(monster)/component/CustomizeMonster.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 
 import { useMutation } from '@tanstack/react-query';
 
-import _ from 'lodash';
+import { unionBy } from 'lodash';
 
 import FormControlLabel from '@components/common/FormControlLabel';
 import BaseText from '@components/common/Text/BaseText';
@@ -104,7 +104,7 @@ function CustomizeMonster() {
     decorationType: DecorationTypes,
     decorationValue: string,
   ) =>
-    _.unionBy(
+    unionBy(
       [
         {
           decorationType,

--- a/src/app/(route)/(monster)/share/components/DoneStep.tsx
+++ b/src/app/(route)/(monster)/share/components/DoneStep.tsx
@@ -1,0 +1,14 @@
+import Button from '@components/common/Button';
+
+export default function DoneStep() {
+  return (
+    <>
+      <div />
+      <nav>
+        <Button variant="primary" size="large" onClick={() => {}}>
+          나도 퇴사몬 만들어보기
+        </Button>
+      </nav>
+    </>
+  );
+}

--- a/src/app/(route)/(monster)/share/components/EncouragementStep.tsx
+++ b/src/app/(route)/(monster)/share/components/EncouragementStep.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+
+import { useAtomValue } from 'jotai';
+
+import Button from '@components/common/Button';
+import BaseText from '@components/common/Text/BaseText';
+
+import { useSendEncouragement } from '@api/monster/queries';
+
+import { idAtom } from '@store/monsterAtom';
+
+type IncouragementStepProps = {
+  goBackToInteraction: () => void;
+  onSendMessage: () => void;
+};
+
+export default function EncouragementStep({
+  goBackToInteraction,
+  onSendMessage,
+}: IncouragementStepProps) {
+  const id = useAtomValue(idAtom);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const { mutate: send } = useSendEncouragement(id, {
+    onSuccess: () => onSendMessage?.(),
+    onError: () => {},
+  });
+
+  const handleSend = () => {
+    send({
+      sender: '빵빵이',
+      content: '테스트입니다.',
+    });
+  };
+
+  useEffect(() => {
+    if (buttonRef.current) {
+      buttonRef.current.disabled = true;
+    }
+  });
+
+  return (
+    <>
+      <BaseText>타이틀</BaseText>
+      <div />
+      <nav className="flex gap-8">
+        <Button variant="secondary" onClick={goBackToInteraction}>
+          뒤로가기
+        </Button>
+        <Button ref={buttonRef} variant="primary" onClick={handleSend}>
+          전송하기
+        </Button>
+      </nav>
+    </>
+  );
+}

--- a/src/app/(route)/(monster)/share/components/InteractionStep.tsx
+++ b/src/app/(route)/(monster)/share/components/InteractionStep.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+import { useAtom } from 'jotai';
+
+import LogoSVG from '@public/icons/logo.svg';
+
+import Button from '@components/common/Button';
+import MonsterFlipCard from '@components/MonsterCard/FlipCard';
+
+import { monsterAtom } from '@store/monsterAtom';
+
+type InteractionStepProps = {
+  goToEncouragement: () => void;
+};
+
+export default function InteractionStep({
+  goToEncouragement,
+}: InteractionStepProps) {
+  const [{ isPending, isError }] = useAtom(monsterAtom);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (buttonRef.current) {
+      buttonRef.current.disabled = true;
+    }
+  });
+
+  // [TODO] Pending, Error 페이지 구현
+  if (isPending)
+    return <div className="h-full w-full text-white">Loading...</div>;
+
+  if (isError) return <div className="h-full w-full text-white">Error</div>;
+
+  const handleFlipped = () => {
+    if (buttonRef.current) {
+      buttonRef.current.disabled = false;
+    }
+  };
+
+  return (
+    <>
+      <header className="flex w-full items-center justify-center">
+        <LogoSVG />
+      </header>
+      <MonsterFlipCard onFlipped={handleFlipped} />
+      <nav>
+        <Button
+          ref={buttonRef}
+          onClick={goToEncouragement}
+          variant="primary"
+          size="large"
+        >
+          응원메세지 작성하기
+        </Button>
+      </nav>
+    </>
+  );
+}

--- a/src/app/(route)/(monster)/share/constants/error.ts
+++ b/src/app/(route)/(monster)/share/constants/error.ts
@@ -1,0 +1,4 @@
+export const ERROR_MESSAGE = {
+  NOT_FOUND: 'Not Found Monster',
+  INVALID: 'Not Valid Monster ID',
+};

--- a/src/app/(route)/(monster)/share/constants/funnel.ts
+++ b/src/app/(route)/(monster)/share/constants/funnel.ts
@@ -1,0 +1,1 @@
+export const funnel = ['interactions', 'encouragement', 'done'] as const;

--- a/src/app/(route)/(monster)/share/error.tsx
+++ b/src/app/(route)/(monster)/share/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+// Error components must be Client Components
+
+import { useEffect } from 'react';
+
+import Button from '@components/common/Button';
+import BaseText from '@components/common/Text/BaseText';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div>
+      <BaseText variant="heading-2" component="h2" color="strong">
+        문제가 발생했어요!
+      </BaseText>
+      <Button onClick={() => reset()}>Try again</Button>
+    </div>
+  );
+}

--- a/src/app/(route)/(monster)/share/layout.tsx
+++ b/src/app/(route)/(monster)/share/layout.tsx
@@ -1,5 +1,3 @@
-import LogoSVG from '@public/icons/logo.svg';
-
 import cn from '@utils/cn';
 
 type Props = {
@@ -14,10 +12,9 @@ function ShareLayout({ children }: Props) {
         'relative m-auto box-border	flex h-dvh w-full max-w-[414px] flex-col items-center overflow-auto overscroll-none',
       )}
     >
-      <header className="flex h-[72px] w-full items-center justify-center">
-        <LogoSVG />
-      </header>
-      {children}
+      <section className="flex h-full w-full flex-col items-center justify-between gap-[28px] p-20">
+        {children}
+      </section>
     </main>
   );
 }

--- a/src/app/(route)/(monster)/share/layout.tsx
+++ b/src/app/(route)/(monster)/share/layout.tsx
@@ -1,0 +1,25 @@
+import LogoSVG from '@public/icons/logo.svg';
+
+import cn from '@utils/cn';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function ShareLayout({ children }: Props) {
+  return (
+    <main
+      style={{ touchAction: 'auto' }}
+      className={cn(
+        'relative m-auto box-border	flex h-dvh w-full max-w-[414px] flex-col items-center overflow-auto overscroll-none',
+      )}
+    >
+      <header className="flex h-[72px] w-full items-center justify-center">
+        <LogoSVG />
+      </header>
+      {children}
+    </main>
+  );
+}
+
+export default ShareLayout;

--- a/src/app/(route)/(monster)/share/page.tsx
+++ b/src/app/(route)/(monster)/share/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useAtom, useSetAtom } from 'jotai';
+
+import Button from '@components/common/Button';
+import MonsterFlipCard from '@components/MonsterCard/FlipCard';
+
+import useQueryString from '@hooks/useQueryString';
+
+import { useUpdateInteraction } from '@api/monster/queries';
+
+import { idAtom, monsterAtom } from '@store/monsterAtom';
+
+export default function SharePage() {
+  const [monsterId] = useQueryString('monsterId');
+
+  const [{ isPending, isError, data: monster }] = useAtom(monsterAtom);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const setId = useSetAtom(idAtom);
+
+  const { mutate } = useUpdateInteraction({
+    // [TODO]: toast
+    onSuccess: () => {},
+    onError(error) {
+      console.log('응원 보내기에 실패했어요.', error);
+    },
+  });
+
+  useEffect(() => {
+    setId(monsterId);
+
+    if (buttonRef.current) {
+      buttonRef.current.disabled = true;
+    }
+
+    return () => setId('');
+  }, [monsterId]);
+
+  // [TODO] Pending, Error 페이지 구현
+  if (isPending)
+    return <div className="h-full w-full text-white">Loading...</div>;
+
+  if (isError) return <div className="h-full w-full text-white">Error</div>;
+
+  const handleFlipped = () => {
+    const { interactionCountPerEncouragement: interactionCount } = monster;
+
+    /** onSuccess시에만 처리가 필요할까요? */
+    if (buttonRef.current) {
+      buttonRef.current.disabled = false;
+    }
+
+    mutate({
+      monsterId,
+      interactionCount,
+    });
+  };
+
+  return (
+    <section className="flex h-full w-full flex-col items-center justify-between gap-[28px] p-20">
+      <MonsterFlipCard onFlipped={handleFlipped} />
+      <Button ref={buttonRef} variant="primary" size="large" disabled>
+        응원메세지 작성하기
+      </Button>
+    </section>
+  );
+}

--- a/src/app/api/api.constants.ts
+++ b/src/app/api/api.constants.ts
@@ -22,5 +22,7 @@ export const API_URLS = {
     DELETE_MONSTER: (monsterId: string | number) => `/monsters/${monsterId}`,
     UPDATE_INTERACTION_COUNT: (monsterId: string | number) =>
       `/monsters/${monsterId}/interactions`,
+    SEND_ENCOURAGEMENT: (monsterId: string | number) =>
+      `/monsters/${monsterId}/encouragement`,
   },
 };

--- a/src/app/api/monster/index.ts
+++ b/src/app/api/monster/index.ts
@@ -9,6 +9,7 @@ import {
   GetMonsterResponse,
   GetMonstersListRequest,
   ModifyMonsterRequest,
+  SendEncouragementRequest,
   UpdateInteractionCountRequest,
   UpdateInteractionCountResponse,
 } from './types';
@@ -69,6 +70,15 @@ const MONSTER_APIS = {
     );
 
     return data;
+  },
+
+  sendEncouragement: (
+    monsterId: string | number,
+    data: SendEncouragementRequest,
+  ) => {
+    return apiInstance.post(API_URLS.MONSTER.SEND_ENCOURAGEMENT(monsterId), {
+      ...data,
+    });
   },
 };
 

--- a/src/app/api/monster/index.ts
+++ b/src/app/api/monster/index.ts
@@ -57,16 +57,18 @@ const MONSTER_APIS = {
     return apiInstance.delete(API_URLS.MONSTER.DELETE_MONSTER(monsterId));
   },
 
-  updateInteractionCount: ({
+  updateInteractionCount: async ({
     monsterId,
     interactionCount,
   }: UpdateInteractionCountRequest) => {
-    return apiInstance.post<UpdateInteractionCountResponse>(
+    const { data } = await apiInstance.post<UpdateInteractionCountResponse>(
       API_URLS.MONSTER.UPDATE_INTERACTION_COUNT(monsterId),
       {
         interactionCount,
       },
     );
+
+    return data;
   },
 };
 

--- a/src/app/api/monster/index.ts
+++ b/src/app/api/monster/index.ts
@@ -3,6 +3,7 @@ import { API_URLS } from '@api/api.constants';
 
 import {
   CreateMonsterRequest,
+  CreateMonsterResponse,
   GetMonsterListResponse,
   GetMonsterRefResponse,
   GetMonsterResponse,
@@ -13,10 +14,13 @@ import {
 } from './types';
 
 const MONSTER_APIS = {
-  createMonster: (data: CreateMonsterRequest) => {
-    return apiInstance.post(API_URLS.MONSTER.CREATE_MONSTER, {
-      ...data,
-    });
+  createMonster: async (data: CreateMonsterRequest) => {
+    return apiInstance.post<CreateMonsterResponse>(
+      API_URLS.MONSTER.CREATE_MONSTER,
+      {
+        ...data,
+      },
+    );
   },
 
   getMonsterById: async (monsterId: string | number) => {

--- a/src/app/api/monster/queries.ts
+++ b/src/app/api/monster/queries.ts
@@ -1,0 +1,20 @@
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+
+import MONSTER_APIS from '.';
+
+import {
+  UpdateInteractionCountRequest,
+  UpdateInteractionCountResponse,
+} from './types';
+
+export const useUpdateInteraction = (
+  options?: UseMutationOptions<
+    UpdateInteractionCountResponse,
+    unknown,
+    UpdateInteractionCountRequest
+  >,
+) =>
+  useMutation({
+    mutationFn: MONSTER_APIS.updateInteractionCount,
+    ...options,
+  });

--- a/src/app/api/monster/queries.ts
+++ b/src/app/api/monster/queries.ts
@@ -3,9 +3,19 @@ import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import MONSTER_APIS from '.';
 
 import {
+  SendEncouragementRequest,
   UpdateInteractionCountRequest,
   UpdateInteractionCountResponse,
 } from './types';
+
+export const useSendEncouragement = (
+  id: string,
+  options?: UseMutationOptions<unknown, unknown, SendEncouragementRequest>,
+) =>
+  useMutation({
+    mutationFn: (data) => MONSTER_APIS.sendEncouragement(id, data),
+    ...options,
+  });
 
 export const useUpdateInteraction = (
   options?: UseMutationOptions<

--- a/src/app/api/monster/types.ts
+++ b/src/app/api/monster/types.ts
@@ -1,10 +1,27 @@
-import { Monster } from '@api/schema/monster';
+import { Decoration, Monster } from '@api/schema/monster';
 
 /** CreateMonster */
-export interface CreateMonsterRequest extends Monster {}
+export interface CreateMonsterRequest
+  extends Omit<
+    Monster,
+    | 'monsterId'
+    | 'interactionCount'
+    | 'currentInteractionCount'
+    | 'monsterDecorations'
+  > {
+  monsterDecorations: Omit<Decoration, 'decorationId'>[];
+}
+
+export interface CreateMonsterResponse extends Omit<Monster, 'rating'> {
+  ownerName: string;
+  interactionCountPerEncouragement: number;
+}
 
 /** GetMonster */
-export interface GetMonsterResponse extends Monster {}
+export interface GetMonsterResponse extends Omit<Monster, 'rating'> {
+  ownerName: string;
+  interactionCountPerEncouragement: number;
+}
 
 /** GetMonsterRef */
 export interface GetMonsterRefResponse extends Monster {}

--- a/src/app/api/monster/types.ts
+++ b/src/app/api/monster/types.ts
@@ -49,3 +49,9 @@ export interface UpdateInteractionCountRequest
 
 export interface UpdateInteractionCountResponse
   extends Pick<Monster, 'monsterId' | 'interactionCount'> {}
+
+/** SendEncouragement */
+export interface SendEncouragementRequest {
+  sender: string;
+  content: string;
+}

--- a/src/app/api/schema/monster.ts
+++ b/src/app/api/schema/monster.ts
@@ -20,7 +20,7 @@ export interface Monster {
   rating: number;
   content: string;
   emotion: keyof typeof Emotion;
-  monsterId: number;
+  monsterId: number | string;
   monsterName: string;
   monsterDecorations: Decoration[];
   interactionCount: number;

--- a/src/app/components/MonsterCard/CardBase.tsx
+++ b/src/app/components/MonsterCard/CardBase.tsx
@@ -5,7 +5,7 @@ import { cva, VariantProps } from 'class-variance-authority';
 import cn from '@utils/cn';
 
 const cardStyles = cva(
-  'relative flex items-center justify-center overflow-hidden border-[10px] border-cool-neutral-7 shadow-3 outline outline-[5px] bg-current',
+  'relative flex items-center justify-center overflow-hidden border-[10px] border-cool-neutral-7 shadow-[0_0_0_5px] bg-current',
   {
     variants: {
       type: {
@@ -13,11 +13,11 @@ const cardStyles = cva(
         flip: ['w-[312px]', 'h-[460px]', 'rounded-[40px]'],
       },
       color: {
-        GREEN: ['text-green-70', 'outline-green-70'],
-        RED_ORANGE: ['text-red-orange-70', 'outline-red-orange-70'],
-        CYAN: ['text-cyan-70', 'outline-cyan-70'],
-        LIGHT_BLUE: ['text-light-blue-70', 'outline-light-blue-70'],
-        VIOLET: ['text-violet-70', 'outline-violet-70'],
+        GREEN: ['text-green-70'],
+        RED_ORANGE: ['text-red-orange-70'],
+        CYAN: ['text-cyan-70'],
+        LIGHT_BLUE: ['text-light-blue-70'],
+        VIOLET: ['text-violet-70'],
       },
     },
     defaultVariants: {

--- a/src/app/components/MonsterCard/CardBase.tsx
+++ b/src/app/components/MonsterCard/CardBase.tsx
@@ -5,7 +5,7 @@ import { cva, VariantProps } from 'class-variance-authority';
 import cn from '@utils/cn';
 
 const cardStyles = cva(
-  'relative flex items-center justify-center overflow-hidden border-[10px] border-cool-neutral-7 shadow-3 outline outline-[5px]',
+  'relative flex items-center justify-center overflow-hidden border-[10px] border-cool-neutral-7 shadow-3 outline outline-[5px] bg-current',
   {
     variants: {
       type: {
@@ -13,11 +13,11 @@ const cardStyles = cva(
         flip: ['w-[312px]', 'h-[460px]', 'rounded-[40px]'],
       },
       color: {
-        green: ['bg-green-70', 'outline-green-70'],
-        'red-orange': ['bg-red-orange-70', 'outline-red-orange-70'],
-        cyan: ['bg-cyan-70', 'outline-cyan-70'],
-        'light-blue': ['bg-light-blue-70', 'outline-light-blue-70'],
-        violet: ['bg-violet-70', 'outline-violet-70'],
+        GREEN: ['text-green-70', 'outline-green-70'],
+        RED_ORANGE: ['text-red-orange-70', 'outline-red-orange-70'],
+        CYAN: ['text-cyan-70', 'outline-cyan-70'],
+        LIGHT_BLUE: ['text-light-blue-70', 'outline-light-blue-70'],
+        VIOLET: ['text-violet-70', 'outline-violet-70'],
       },
     },
     defaultVariants: {
@@ -34,8 +34,11 @@ export default function CardBase({
   children,
   type,
   color,
+  ...rest
 }: CardBaseProps) {
   return (
-    <div className={cn(cardStyles({ type, color }), className)}>{children}</div>
+    <div className={cn(cardStyles({ type, color }), className)} {...rest}>
+      {children}
+    </div>
   );
 }

--- a/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
+++ b/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
@@ -19,6 +19,7 @@ type CounterBoxProps = PropsWithChildren & {
   endAt: number;
   step?: number;
   delay?: number;
+  helperText?: string;
   onCount: Dispatch<SetStateAction<number>>;
   onCountEnd: () => void;
 };
@@ -29,6 +30,7 @@ export default function CounterBox({
   endAt,
   step = 1,
   delay = 300,
+  helperText,
   onCount,
   onCountEnd,
 }: CounterBoxProps) {
@@ -49,6 +51,7 @@ export default function CounterBox({
     if (count + startAt < endAt) {
       setCount((prev) => prev + step);
       setVisibility('visible');
+
       debouncedCount(count);
     } else {
       onCountEnd();
@@ -57,30 +60,68 @@ export default function CounterBox({
 
   return (
     <>
-      <motion.button
-        className="pointer absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
-        animate="initial"
-        whileHover={{ scale: 1.15 }}
-        whileTap={{
-          scale: 0.8,
-          rotate: 5 * (Math.random() * 2 - 1),
-        }}
-        transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+      <motion.div
+        initial="hidden"
+        animate="visible"
         variants={{
-          initial: {
-            y: [-5, 5],
-            transition: {
-              delay: 0.5,
-              duration: 1,
-              repeat: Infinity,
-              repeatType: 'mirror',
-            },
+          hidden: {
+            opacity: 0,
+          },
+          visible: {
+            opacity: 1,
+            transition: { staggerChildren: 0.5 },
           },
         }}
-        onClick={handleClick}
       >
-        {children}
-      </motion.button>
+        <motion.button
+          className="pointer absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
+          whileHover={{ scale: 1.15 }}
+          whileTap={{
+            scale: 0.8,
+            rotate: 5 * (Math.random() * 2 - 1),
+          }}
+          transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+          variants={{
+            visible: {
+              y: [-10, 8],
+              transition: {
+                delay: 0.5,
+                duration: 0.5,
+                repeat: Infinity,
+                repeatType: 'mirror',
+              },
+            },
+          }}
+          onClick={handleClick}
+        >
+          {children}
+        </motion.button>
+        {helperText && (
+          <motion.div
+            className="absolute bottom-0 left-0 right-0 mx-auto h-max w-max rounded-circular bg-[#171719bd] px-[16px] py-[6px]"
+            variants={{
+              hidden: {
+                y: '200%',
+              },
+              visible: {
+                y: -16,
+                transition: {
+                  duration: 0.5,
+                },
+              },
+            }}
+          >
+            <BaseText
+              component="span"
+              variant="label-2"
+              weight="medium"
+              color="normal"
+            >
+              {helperText}
+            </BaseText>
+          </motion.div>
+        )}
+      </motion.div>
       <BaseText
         variant="heading-1"
         color="normal"

--- a/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
+++ b/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
@@ -58,10 +58,25 @@ export default function CounterBox({
   return (
     <>
       <motion.button
-        className="absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
+        className="pointer absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
+        animate="initial"
         whileHover={{ scale: 1.15 }}
-        whileTap={{ scale: 0.9 }}
+        whileTap={{
+          scale: 0.8,
+          rotate: 5 * (Math.random() * 2 - 1),
+        }}
         transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+        variants={{
+          initial: {
+            y: [-5, 5],
+            transition: {
+              delay: 0.5,
+              duration: 1,
+              repeat: Infinity,
+              repeatType: 'mirror',
+            },
+          },
+        }}
         onClick={handleClick}
       >
         {children}

--- a/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
+++ b/src/app/components/MonsterCard/FlipCard/CounterBox.tsx
@@ -1,0 +1,81 @@
+import {
+  CSSProperties,
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useMemo,
+  useState,
+} from 'react';
+
+import { motion } from 'framer-motion';
+import { debounce } from 'lodash';
+
+import BaseText from '@components/common/Text/BaseText';
+
+type VisibilityType = CSSProperties['visibility'];
+
+type CounterBoxProps = PropsWithChildren & {
+  startAt: number;
+  endAt: number;
+  step?: number;
+  delay?: number;
+  onCount: Dispatch<SetStateAction<number>>;
+  onCountEnd: () => void;
+};
+
+export default function CounterBox({
+  children,
+  startAt,
+  endAt,
+  step = 1,
+  delay = 300,
+  onCount,
+  onCountEnd,
+}: CounterBoxProps) {
+  const [count, setCount] = useState(0);
+  const [visibility, setVisibility] = useState<VisibilityType>('hidden');
+
+  const debouncedCount = useMemo(
+    () =>
+      debounce((clickCount) => {
+        onCount((prev) => Math.min(prev + clickCount + step, endAt));
+        setCount(0);
+        setVisibility('hidden');
+      }, delay),
+    [endAt, step, delay, onCount],
+  );
+
+  const handleClick = () => {
+    if (count + startAt < endAt) {
+      setCount((prev) => prev + step);
+      setVisibility('visible');
+      debouncedCount(count);
+    } else {
+      onCountEnd();
+    }
+  };
+
+  return (
+    <>
+      <motion.button
+        className="absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
+        whileHover={{ scale: 1.15 }}
+        whileTap={{ scale: 0.9 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+        onClick={handleClick}
+      >
+        {children}
+      </motion.button>
+      <BaseText
+        variant="heading-1"
+        color="normal"
+        className="fixed bottom-0 left-0 right-0 top-0 m-auto h-[50px] w-[50px] select-none overflow-hidden rounded-8 bg-[#ffffff10] text-center leading-[50px] backdrop-blur-sm"
+        style={{
+          visibility,
+        }}
+      >
+        {count}
+      </BaseText>
+    </>
+  );
+}

--- a/src/app/components/MonsterCard/FlipCard/Dropdown.tsx
+++ b/src/app/components/MonsterCard/FlipCard/Dropdown.tsx
@@ -1,0 +1,22 @@
+import EllipsisSVG from '@public/icons/ellipsis.svg';
+
+import Icon from '@components/common/Icon';
+
+export default function Dropdown() {
+  const handleDropdown = () => {
+    /**
+     * 이후 메인 페이지 로직 작성시 추가 예정
+     */
+  };
+
+  return (
+    <div>
+      <button onClick={handleDropdown}>
+        {' '}
+        <Icon className="text-cool-neutral-40">
+          <EllipsisSVG />
+        </Icon>
+      </button>
+    </div>
+  );
+}

--- a/src/app/components/MonsterCard/FlipCard/HiddenStory.tsx
+++ b/src/app/components/MonsterCard/FlipCard/HiddenStory.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/navigation';
+
+import Button from '@components/common/Button';
+import BaseText from '@components/common/Text/BaseText';
+
+type HiddenStoryTypes = React.PropsWithChildren<{
+  owner?: boolean;
+}>;
+
+export default function HiddenStory({
+  children,
+  owner = false,
+}: HiddenStoryTypes) {
+  const { replace } = useRouter();
+
+  const handleClick = () => {
+    // [TODO] 내용 수정 페이지 경로로 변경
+    replace('/');
+  };
+
+  return (
+    <div className="flex h-full select-none flex-col gap-20 rounded-[28px] bg-cool-neutral-17 p-20 shadow-5">
+      <BaseText
+        className="my-auto flex max-h-full overflow-y-auto text-center"
+        component="p"
+        variant="body-2"
+        weight="medium"
+        color="strong"
+        wrap
+      >
+        {children}
+      </BaseText>
+      {owner && (
+        <Button
+          variant="secondary"
+          size="small"
+          className="w-full"
+          onClick={handleClick}
+        >
+          내용 수정하기
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/MonsterCard/FlipCard/HiddenStory.tsx
+++ b/src/app/components/MonsterCard/FlipCard/HiddenStory.tsx
@@ -19,7 +19,7 @@ export default function HiddenStory({
   };
 
   return (
-    <div className="flex h-full select-none flex-col gap-20 rounded-[28px] bg-cool-neutral-17 p-20 shadow-5">
+    <div className="flex h-full w-full select-none flex-col gap-20 rounded-[28px] bg-cool-neutral-17 p-20 shadow-5">
       <BaseText
         className="my-auto flex max-h-full overflow-y-auto text-center"
         component="p"

--- a/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
+++ b/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
@@ -14,11 +14,11 @@ export default function ProgressBar({ percent }: ProgressBarProps) {
         <motion.div
           className="h-full rounded-circular bg-current"
           initial={{ width: 0 }}
-          animate={{ width: `${percent}%` }}
+          animate={{ width: `${Math.min(percent, 100)}%` }}
         />
       </div>
       <BaseText component="span" variant="label-1" weight="semibold">
-        {percent}%
+        {Math.min(percent, 100)}%
       </BaseText>
     </div>
   );

--- a/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
+++ b/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
@@ -1,0 +1,25 @@
+import { motion } from 'framer-motion';
+
+import BaseText from '@components/common/Text/BaseText';
+
+type ProgressBarProps = {
+  percent: number;
+};
+
+export default function ProgressBar({ percent }: ProgressBarProps) {
+  return (
+    <div className="flex items-center gap-10 last:text-inherit">
+      <div className="h-[14px] w-[194px] rounded-circular bg-cool-neutral-17">
+        {/* Indicator */}
+        <motion.div
+          className="h-full rounded-circular bg-current"
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+        />
+      </div>
+      <BaseText component="span" variant="label-1" weight="semibold">
+        {percent}%
+      </BaseText>
+    </div>
+  );
+}

--- a/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
+++ b/src/app/components/MonsterCard/FlipCard/ProgressBar.tsx
@@ -3,22 +3,25 @@ import { motion } from 'framer-motion';
 import BaseText from '@components/common/Text/BaseText';
 
 type ProgressBarProps = {
-  percent: number;
+  value: number;
+  max?: number;
 };
 
-export default function ProgressBar({ percent }: ProgressBarProps) {
+export default function ProgressBar({ value, max = 100 }: ProgressBarProps) {
+  const percent = (Math.min(value / max) * 100).toFixed(1);
+
   return (
     <div className="flex items-center gap-10 last:text-inherit">
-      <div className="h-[14px] w-[194px] rounded-circular bg-cool-neutral-17">
+      <div className="h-[14px] w-[194px] overflow-hidden rounded-circular bg-cool-neutral-17">
         {/* Indicator */}
         <motion.div
           className="h-full rounded-circular bg-current"
           initial={{ width: 0 }}
-          animate={{ width: `${Math.min(percent, 100)}%` }}
+          animate={{ width: `${percent}%` }}
         />
       </div>
       <BaseText component="span" variant="label-1" weight="semibold">
-        {Math.min(percent, 100)}%
+        {percent}%
       </BaseText>
     </div>
   );

--- a/src/app/components/MonsterCard/FlipCard/index.tsx
+++ b/src/app/components/MonsterCard/FlipCard/index.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import Image from 'next/image';
+
+import { useEffect, useState } from 'react';
+
+import { useAtom } from 'jotai';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import BaseText from '@components/common/Text/BaseText';
+import CardBase from '@components/MonsterCard/CardBase';
+
+import { findObjectInArray } from '@utils/find';
+
+import { monsterAtom } from '@store/monsterAtom';
+
+import CounterBox from './CounterBox';
+import Dropdown from './Dropdown';
+import HiddenStory from './HiddenStory';
+import ProgressBar from './ProgressBar';
+
+type MonsterFlipCardProps = {
+  isOwner?: boolean;
+  onFlipped?: (arg?: unknown) => void;
+};
+
+export default function MonsterFlipCard({
+  isOwner = false,
+  onFlipped,
+}: MonsterFlipCardProps) {
+  const [{ data: monster }] = useAtom(monsterAtom);
+
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const findDecoration = findObjectInArray(
+    monster?.monsterDecorations || [],
+    'decorationType',
+  );
+
+  const COLOR = findDecoration?.('BACKGROUND_COLOR')?.decorationValue;
+
+  const handleCardToggle = () => {
+    if (!isAnimating) {
+      setIsFlipped(!isFlipped);
+      setIsAnimating(true);
+    }
+  };
+
+  useEffect(() => {
+    if (monster) {
+      if (totalCount >= monster?.interactionCountPerEncouragement) {
+        setIsFlipped(true);
+
+        if (onFlipped) onFlipped();
+      }
+    }
+  }, [totalCount, monster, setIsFlipped]);
+
+  return (
+    <AnimatePresence>
+      <div
+        className="h-[460px] w-[312px]"
+        style={{
+          perspective: '1000px',
+        }}
+      >
+        <motion.div
+          className="h-full w-full"
+          initial={false}
+          animate={{ rotateY: isFlipped ? 180 : 360 }}
+          transition={{ duration: 0.85, animationDirection: 'normal' }}
+          onAnimationComplete={() => setIsAnimating(false)}
+          style={{
+            transition: 'transform 0.6',
+            transformStyle: 'preserve-3d',
+          }}
+        >
+          {/* Flip Card Front */}
+          <CardBase
+            type="flip"
+            color={COLOR}
+            className="absolute overflow-visible"
+            style={{
+              backfaceVisibility: 'hidden',
+            }}
+          >
+            <div className="flex h-full w-full flex-col justify-between">
+              <div className="relative h-full w-full overflow-hidden rounded-t-[28px] p-16">
+                <BaseText
+                  component="h3"
+                  variant="label-2"
+                  weight="semibold"
+                  className="mx-auto w-max text-cool-neutral-7"
+                >
+                  {monster?.ownerName}님의 퇴사몬
+                </BaseText>
+
+                <CounterBox
+                  startAt={totalCount}
+                  endAt={monster?.interactionCountPerEncouragement || 0}
+                  onCount={setTotalCount}
+                  onComplete={handleCardToggle}
+                  {...(isOwner
+                    ? {}
+                    : { helperText: '화면을 연타하면 사연을 볼 수 있어요' })}
+                >
+                  <Image
+                    src="/sample.png"
+                    width={227}
+                    height={192}
+                    alt="Sample Monster"
+                  />
+                </CounterBox>
+              </div>
+              <div className="flex h-[88px] flex-col gap-12 rounded-b-[28px] bg-cool-neutral-7 p-20">
+                <div className="flex items-center justify-between">
+                  <div className="flex gap-8">
+                    <div className="flex rounded-6 bg-[#70737c47] px-8 py-4">
+                      <BaseText
+                        component="span"
+                        variant="caption-2"
+                        color="neutral"
+                      >
+                        스트레스 {}
+                      </BaseText>
+                    </div>
+                    <BaseText
+                      overflow="truncate"
+                      component="span"
+                      variant="body-1"
+                      weight="semibold"
+                      color="neutral"
+                    >
+                      {monster?.monsterName}
+                    </BaseText>
+                  </div>
+                  {isOwner && <Dropdown />}
+                </div>
+                <ProgressBar
+                  value={totalCount}
+                  max={monster?.interactionCountPerEncouragement}
+                />
+              </div>
+            </div>
+          </CardBase>
+
+          {/* Flip Card Back */}
+          <CardBase
+            role="none" // DO NOT REMOVE!!!
+            type="flip"
+            color={COLOR}
+            className="absolute overflow-visible"
+            onClick={handleCardToggle}
+            style={{
+              transform: 'rotateY(180deg)',
+              backfaceVisibility: 'hidden',
+            }}
+          >
+            <HiddenStory owner={isOwner}>{monster?.content}</HiddenStory>
+          </CardBase>
+        </motion.div>
+      </div>
+    </AnimatePresence>
+  );
+}

--- a/src/app/components/common/Button/index.tsx
+++ b/src/app/components/common/Button/index.tsx
@@ -8,44 +8,37 @@ import Icon from '@components/common/Icon';
 
 import cn from '@utils/cn';
 
-const buttonStyles = cva('body-2-semibold h-[55px]', {
-  variants: {
-    variant: {
-      primary: [
-        'bg-[--color-background-button-primary-base]',
-        'text-cool-neutral-10',
-      ],
-      secondary: ['bg-cool-neutral-23', 'text-cool-neutral-90A'],
-      ghost: ['bg-transparent', 'text-cool-neutral-99'],
+const buttonStyles = cva(
+  'body-2-semibold h-[55px] disabled:!text-cool-neutral-70A disabled:!bg-cool-neutral-22',
+  {
+    variants: {
+      variant: {
+        primary: [
+          'bg-[--color-background-button-primary-base]',
+          'text-cool-neutral-10',
+        ],
+        secondary: ['bg-cool-neutral-23', 'text-cool-neutral-90A'],
+        ghost: ['bg-transparent', 'text-cool-neutral-99'],
+      },
+      size: {
+        small: [
+          'label-1-medium',
+          'w-[128px]',
+          'h-[44px]',
+          'rounded-8',
+          'px-12',
+          'py-[10px]',
+        ],
+        medium: ['w-[164px]', 'rounded-12', 'px-16', 'py-[10px]'],
+        large: ['w-[335px]', 'rounded-12', 'px-16', 'py-[10px]'],
+      },
     },
-    size: {
-      small: [
-        'label-1-medium',
-        'w-[128px]',
-        'h-[44px]',
-        'rounded-8',
-        'px-12',
-        'py-[10px]',
-      ],
-      medium: ['w-[164px]', 'rounded-12', 'px-16', 'py-[10px]'],
-      large: ['w-[335px]', 'rounded-12', 'px-16', 'py-[10px]'],
-    },
-    disabled: {
-      true: 'text-cool-neutral-70A',
+    defaultVariants: {
+      variant: 'primary',
+      size: 'medium',
     },
   },
-  compoundVariants: [
-    {
-      variant: ['primary', 'secondary'],
-      disabled: true,
-      className: ['bg-cool-neutral-22'],
-    },
-  ],
-  defaultVariants: {
-    variant: 'primary',
-    size: 'medium',
-  },
-});
+);
 
 export type ButtonProps = React.PropsWithChildren<
   VariantProps<typeof buttonStyles> & {
@@ -62,7 +55,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
     <button
       ref={ref}
       disabled={disabled || loading}
-      className={cn(buttonStyles({ variant, size, disabled }), className)}
+      className={cn(buttonStyles({ variant, size }), className)}
       {...rest}
     >
       {!loading && children}

--- a/src/app/middlewares/withSignUpHandle.ts
+++ b/src/app/middlewares/withSignUpHandle.ts
@@ -65,7 +65,7 @@ function withSignUpHandle(middleware: NextMiddleware) {
       const redirect = request.nextUrl.clone();
       redirect.pathname = code === 102 ? '/' : redirect.pathname;
       redirect.search =
-        (code === 100 && `code${code}`) ||
+        (code === 100 && `code=${code}`) ||
         (code === 101 && `code=${code}&user=${username}`) ||
         '';
 

--- a/src/app/store/monsterAtom.ts
+++ b/src/app/store/monsterAtom.ts
@@ -1,0 +1,16 @@
+import { atom } from 'jotai';
+import { atomWithQuery } from 'jotai-tanstack-query';
+
+import { AxiosResponse } from 'axios';
+
+import MONSTER_APIS from '@api/monster';
+import { GetMonsterResponse } from '@api/monster/types';
+
+export const idAtom = atom('');
+
+export const monsterAtom = atomWithQuery((get) => ({
+  retry: 1,
+  queryKey: ['monster', get(idAtom)],
+  queryFn: () => MONSTER_APIS.getMonsterById(get(idAtom)),
+  select: (data: AxiosResponse<GetMonsterResponse>) => data.data,
+}));

--- a/src/app/store/monsterAtom.ts
+++ b/src/app/store/monsterAtom.ts
@@ -10,6 +10,7 @@ export const idAtom = atom('');
 
 export const monsterAtom = atomWithQuery((get) => ({
   retry: 1,
+  enabled: !!get(idAtom),
   queryKey: ['monster', get(idAtom)],
   queryFn: () => MONSTER_APIS.getMonsterById(get(idAtom)),
   select: (data: AxiosResponse<GetMonsterResponse>) => data.data,

--- a/src/app/utils/find.ts
+++ b/src/app/utils/find.ts
@@ -1,6 +1,6 @@
-import _ from 'lodash';
+import { curry } from 'lodash';
 
-export const findObjectInArray = _.curry(
+export const findObjectInArray = curry(
   <T extends Record<string, unknown>>(
     array: T[],
     key: keyof T,


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #35 
- 관련 Figma : [피그마](https://www.figma.com/design/nXfx6MKE8W3BF90Ql5UGdR/%5B%E1%84%83%E1%85%B5%E1%84%8C%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%5D-%E1%84%91%E1%85%B3%E1%84%85%E1%85%A9%E1%84%80%E1%85%B3%E1%84%85%E1%85%A1%E1%84%91%E1%85%B5_0420ver?node-id=499-9771&t=Cf3nqadslWoYrbT1-4)

### ⚙️ Changes
<!-- 변경한 내용에 대한 간단한 요약을 설명합니다. --> 

- **서브 유저 플로우**  
  - MonsterFlipCard 컴포넌트를 구현하였습니다.
    - 이후 메인 유저에서의 재사용을 고려하여 `src/components` 하위에 구현하였습니다. 
    - 내부 Dropdown 컴포넌트의 경우 메인 유저 로직 구현 시 추가하도록 하겠습니다. 
    
  - 서브 유저 페이지를 구현하였습니다. 
    - SharePage 내부 Funnel에서 사용되는 각 스텝 컴포넌트를 분리하여 틀을 작성하였습니다. 
      내부에 미리 작성해두신 로직을 추가해주시면 됩니다. 
      (**Step**: InteractionStep, EncouragementStep, DoneStep)
    - EncouragementStep 컴포넌트 내부에서 사용 될 useSendEncouragement 쿼리 훅 추가하였습니다. (`src/app/api/monster/queries.ts` 내부 작성)
    - InteractionStep 컴포넌트 내부 Pending 및 Error 페이지는 추후 디자인이 나오면 구현하도록 하겠습니다.

  - monsterAtom 추가하였습니다. (`src/app/store` 내부 작성)
  - 응원의 메세지 보내기 API 추가하였습니다.
  - [jotai-tanstack-query](https://jotai.org/docs/extensions/query) 관련 패키지를 추가하였습니다. (TanStack Query와 integration을 위한 Jotai 익스텐션 라이브러리)

- **관련 기타 변경 사항** 
  - CardBase 컴포넌트
    별도의 outline 컬러를 지정하지 않더라도 색상을 상속받도록 boxShadow로 부분 수정하였습니다.
  - Button 컴포넌트
    ref 조작 시 disabled 제대로 처리되지않는 문제로 disabled variant를 제거 후  CSS 클래스로 처리하도록 수정하였습니다.
