### PR TITLE
홈 화면 Header, RefCard 컴포넌트 추가

### DIFF
--- a/src/app/(route)/(monster)/component/MainHeader/index.tsx
+++ b/src/app/(route)/(monster)/component/MainHeader/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import Header from '@components/Header';
+
+import useDrawer from '@hooks/useDrawer';
+
+import Menu from '../MenuDrawer';
+
+export default function MainHeader() {
+  const { openDrawer } = useDrawer(() => <Menu />);
+
+  return (
+    <Header className="grid grid-cols-6 gap-4">
+      <Header.LinkLogo size={24} href="/" className="col-span-4 col-start-2" />
+      <Header.IconButton
+        className="col-span-1 ml-auto"
+        name="hamburger"
+        onClick={() => openDrawer()}
+      />
+    </Header>
+  );
+}

--- a/src/app/(route)/(monster)/component/Message/MessageList.tsx
+++ b/src/app/(route)/(monster)/component/Message/MessageList.tsx
@@ -11,7 +11,7 @@ import useModal from '@hooks/useModal';
 
 import { getNextMessageList } from '@api/message/list';
 import MessageQueryFactory from '@api/message/query/factory';
-import { getRefMonster } from '@api/monster';
+import MonsterQueryFactory from '@api/monster/query/factory';
 
 import type { Unpromise } from '@type/util';
 
@@ -35,8 +35,7 @@ function MessageList() {
     data: { monsterId },
   } = useSuspenseQuery({
     retry: 1,
-    queryKey: ['my-monster'],
-    queryFn: () => getRefMonster(),
+    ...MonsterQueryFactory.reference,
   });
 
   const {

--- a/src/app/(route)/(monster)/component/cards/RefMonsterFlipCard/index.tsx
+++ b/src/app/(route)/(monster)/component/cards/RefMonsterFlipCard/index.tsx
@@ -2,14 +2,18 @@
 
 import { useRouter } from 'next/navigation';
 
-import { useCallback, useState } from 'react';
+import {
+  MouseEventHandler,
+  TouchEventHandler,
+  useCallback,
+  useState,
+} from 'react';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { AxiosError } from 'axios';
 
 import MonsterFlipCard from '@components/cards/MonsterFlipCard';
-import CharacterCanvas from '@components/CharacterCanvas';
 import Button from '@components/common/Button';
 import BaseText from '@components/common/Text/BaseText';
 import ProgressBar from '@components/ProgressBar';
@@ -17,10 +21,11 @@ import ProgressBar from '@components/ProgressBar';
 import { Adapter } from '@utils/client/adapter';
 import transformMonster from '@utils/client/transform-monster';
 
+import { useUpdateInteraction } from '@api/interaction/query/hooks';
 import MonsterQueryFactory, { MonsterKeys } from '@api/monster/query/factory';
 import { GetMonsterRefResponse } from '@api/monster/types';
 
-import { ActionMenu, StressLevelBadge } from '../_ui';
+import { ActionMenu, MonsterCounterBox, StressLevelBadge } from '../_ui';
 
 const CARD_WIDTH = 312;
 const CARD_HEIGHT = 460;
@@ -34,43 +39,102 @@ export default function RefMonsterFlipCard() {
     ReturnType<typeof transformMonster<GetMonsterRefResponse>>,
     MonsterKeys['reference']['queryKey']
   >({
-    ...MonsterQueryFactory.reference(),
+    ...MonsterQueryFactory.reference,
     select: useCallback(
       (data: GetMonsterRefResponse) => Adapter.from(data).to(transformMonster),
       [],
     ),
   });
 
+  const { mutate: updateCount } = useUpdateInteraction(monster.monsterId);
+
+  const [clear, setClear] = useState(
+    () => monster.currentInteractionCount >= monster.interactionCount,
+  );
   const [flipped, setFlipped] = useState(false);
+  const [totalCount, setTotalCount] = useState(monster.currentInteractionCount);
+
+  const [prevPageX, setPrevPageX] = useState<number | null>(null);
+
+  const { BACKGROUND_COLOR, ...restDecos } = monster.decorations;
+
+  const ITEMS = Object.values(restDecos);
 
   const toggleCard = () => setFlipped((prev) => !prev);
 
-  console.log('monster : ', monster);
+  const handleTouchMove: TouchEventHandler = (event) => {
+    const touch = event.touches[0]!;
+
+    if (!prevPageX) {
+      setPrevPageX(touch.pageX);
+    } else if (Math.abs(touch.pageX - prevPageX) > 25) {
+      toggleCard();
+    }
+  };
+
+  const handleTouchEnd: TouchEventHandler = () => {
+    setPrevPageX(null);
+  };
+
+  const handleMouseDown: MouseEventHandler = (event) => {
+    setPrevPageX(event.pageX);
+  };
+
+  const handleMouseUp: MouseEventHandler = (event) => {
+    if (!prevPageX) return;
+    if (Math.abs(event.pageX - prevPageX) > 5) {
+      toggleCard();
+      setTimeout(() => setPrevPageX(null));
+    } else {
+      setPrevPageX(null);
+    }
+  };
+
   return (
     <MonsterFlipCard
       className="mx-auto"
       width={CARD_WIDTH}
       height={CARD_HEIGHT}
       flipped={flipped}
-      color={monster.decorations.BACKGROUND_COLOR}
+      color={BACKGROUND_COLOR}
+      // Mobile
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      // PC
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
     >
-      <MonsterFlipCard.ActionArea onClick={toggleCard}>
-        <div className="relative m-auto h-[260px] w-[260px]">
-          <CharacterCanvas
-            className="h-full w-full"
-            type={monster.type}
-            status={monster.status}
-          />
-          <CharacterCanvas
-            className="absolute h-full w-full"
-            // [TODO] 이후 서버 아이템 BACKGROUND_COLOR 이외의 카테고리 허용 시 변경
-            items={['laptop', 'coffee', 'glasses']}
-          />
-        </div>
+      <MonsterFlipCard.ActionArea
+        className="overflow-hidden p-0"
+        style={{
+          pointerEvents: prevPageX ? 'unset' : 'auto',
+        }}
+      >
+        <MonsterCounterBox
+          items={ITEMS}
+          type={monster.type}
+          clear={clear}
+          startAt={totalCount}
+          endAt={monster.interactionCount}
+          onCount={(count) => {
+            if (!prevPageX) {
+              updateCount(count);
+              setTotalCount((prev) =>
+                Math.min(prev + count, monster.interactionCount),
+              );
+            }
+          }}
+          onComplete={() => {
+            setClear(true);
+          }}
+        />
       </MonsterFlipCard.ActionArea>
-      <MonsterFlipCard.Content>
+      <MonsterFlipCard.Content
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+      >
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-8">
+          <div className="pointer-event-none flex select-none items-center gap-8">
             <StressLevelBadge level={monster.ratingRange} />
             <BaseText
               overflow="truncate"
@@ -85,7 +149,7 @@ export default function RefMonsterFlipCard() {
           <ActionMenu targetId={monster.monsterId} />
         </div>
         <ProgressBar
-          value={monster.currentInteractionCount}
+          value={totalCount}
           max={monster.interactionCount}
           label="percent"
         />

--- a/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/index.tsx
+++ b/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/index.tsx
@@ -110,7 +110,7 @@ export default function SharedMonsterFlipCard({
         <BaseText
           variant="label-2"
           weight="semibold"
-          className="absolute left-0 right-0 mx-auto w-max p-16 text-cool-neutral-22"
+          className="absolute left-0 right-0 z-[10] mx-auto w-max p-16 text-cool-neutral-22"
         >
           {monster.ownerName}님의 퇴사몬
         </BaseText>
@@ -119,7 +119,11 @@ export default function SharedMonsterFlipCard({
           type={monster.type}
           clear={clear}
           startAt={totalCount}
-          onCount={setTotalCount}
+          onCount={(count) => {
+            setTotalCount((prev) =>
+              Math.min(prev + count, monster.interactionCount),
+            );
+          }}
           endAt={monster.interactionCountPerEncouragement}
           onComplete={onComplete}
         />

--- a/src/app/(route)/(monster)/component/cards/SquareMonsterCard/index.tsx
+++ b/src/app/(route)/(monster)/component/cards/SquareMonsterCard/index.tsx
@@ -7,17 +7,25 @@ import OutlineCard, {
 } from '@components/cards/OutlineCard';
 import BaseText from '@components/common/Text/BaseText';
 
+import cn from '@utils/cn';
+
 type SquareMonsterCardProps = OutlineCardProps & {
   name: string;
 };
 
 const SquareMonsterCard = forwardRef<HTMLDivElement, SquareMonsterCardProps>(
-  function SquareMonsterCard({ children, color, name, ...rest }, ref) {
+  function SquareMonsterCard(
+    { className, children, color, name, ...rest },
+    ref,
+  ) {
     return (
       <OutlineCard
         ref={ref}
         color={color}
-        className="aspect-square h-[240px] w-[240px] rounded-[36px]"
+        className={cn(
+          'aspect-square h-[240px] w-[240px] rounded-[36px]',
+          className,
+        )}
         {...rest}
       >
         {children}

--- a/src/app/(route)/(monster)/component/cards/_ui/MonsterCounterBox.tsx
+++ b/src/app/(route)/(monster)/component/cards/_ui/MonsterCounterBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { debounce } from 'lodash';
 
@@ -43,6 +43,7 @@ const ConfettiMap = {
 
 export default function MonsterCounterBox({
   type = 'sad',
+  background,
   items,
   startAt,
   endAt,
@@ -69,41 +70,31 @@ export default function MonsterCounterBox({
     destroyCanvas();
   }
 
-  useEffect(() => {
-    if (isMouseDown) {
-      addConfetti(ConfettiMap[type]);
-    }
-  }, [isMouseDown]);
-
   return (
-    <>
-      <CounterBox
-        startAt={startAt}
-        endAt={endAt}
-        onCount={onCount}
-        onComplete={onComplete}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-      >
-        <div className="h-[240px] w-[240px] pb-[32px]">
-          {/* Layer0: 기본 캐릭터 */}
-          <CharacterCanvas
-            className="h-full w-full"
-            type={type}
-            status={clear || isMouseDown ? 'after' : 'before'}
-          />
-          {/* Layer1: 캐릭터 아이템 */}
-          <CharacterCanvas
-            className="absolute left-0 top-0 h-full w-full"
-            items={items}
-          />
-          {/* Layer2: 이펙트 */}
-        </div>
-      </CounterBox>
-      <canvas
-        ref={canvasRef}
-        className="pointer-events-none absolute h-full w-full select-none"
-      />
-    </>
+    <CounterBox
+      startAt={startAt}
+      endAt={endAt}
+      onCount={(count) => {
+        onCount(count);
+        addConfetti(ConfettiMap[type]);
+      }}
+      onComplete={onComplete}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+    >
+      <div className="h-inherit w-inherit pb-[32px]">
+        <CharacterCanvas
+          background={background}
+          className="h-full w-full"
+          type={type}
+          items={items}
+          status={clear || isMouseDown ? 'after' : 'before'}
+        />
+        <canvas
+          ref={canvasRef}
+          className="pointer-events-none absolute left-0 top-0 h-full w-full select-none"
+        />
+      </div>
+    </CounterBox>
   );
 }

--- a/src/app/(route)/(monster)/component/cards/_ui/MonsterCounterBox.tsx
+++ b/src/app/(route)/(monster)/component/cards/_ui/MonsterCounterBox.tsx
@@ -15,13 +15,10 @@ type MonsterCounterBoxPropps = CharacterCanvasProps &
     clear?: boolean;
   };
 
-const HEART_IMAGE_URL = '/images/heart0000.png';
-const THUNDER_IMAGE_URL = '/images/thunder0000.png';
-
 const ConfettiMap = {
   mad: {
     image: {
-      src: THUNDER_IMAGE_URL,
+      src: '/images/thunder0000.png',
       width: 75,
       height: 75,
     },
@@ -31,7 +28,7 @@ const ConfettiMap = {
   },
   sad: {
     image: {
-      src: HEART_IMAGE_URL,
+      src: '/images/heart0000.png',
       width: 50,
       height: 50,
     },
@@ -56,6 +53,11 @@ export default function MonsterCounterBox({
 
   const [isMouseDown, setIsMouseDown] = useState(false);
 
+  const handleCount = (count: number) => {
+    onCount(count);
+    addConfetti(ConfettiMap[type]);
+  };
+
   const handleMouseDown = debounce(() => !clear && setIsMouseDown(true), 5000, {
     leading: true,
     trailing: false,
@@ -71,30 +73,27 @@ export default function MonsterCounterBox({
   }
 
   return (
-    <CounterBox
-      startAt={startAt}
-      endAt={endAt}
-      onCount={(count) => {
-        onCount(count);
-        addConfetti(ConfettiMap[type]);
-      }}
-      onComplete={onComplete}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-    >
-      <div className="h-inherit w-inherit pb-[32px]">
+    <>
+      <CounterBox
+        startAt={startAt}
+        endAt={endAt}
+        onCount={handleCount}
+        onComplete={onComplete}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+      >
         <CharacterCanvas
-          background={background}
           className="h-full w-full"
           type={type}
-          items={items}
           status={clear || isMouseDown ? 'after' : 'before'}
+          items={items}
+          background={background}
         />
-        <canvas
-          ref={canvasRef}
-          className="pointer-events-none absolute left-0 top-0 h-full w-full select-none"
-        />
-      </div>
-    </CounterBox>
+      </CounterBox>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute left-0 top-0 h-full w-full select-none"
+      />
+    </>
   );
 }

--- a/src/app/(route)/(monster)/monster/[slug]/result/components/AnimatedSpreadCard.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/result/components/AnimatedSpreadCard.tsx
@@ -11,7 +11,7 @@ const MotionSquareMonsterCard = motion(SquareMonsterCard);
 
 type AnimatedSpreadCardProps = PropsWithChildren & {
   name: string;
-  color: string;
+  color?: string;
 };
 
 export default function AnimatedSpreadCard({
@@ -33,10 +33,10 @@ export default function AnimatedSpreadCard({
         initial="offscreen"
         whileInView="onscreen"
         viewport={{ once: true, amount: 0.8 }}
-        className="h-[240px] w-[240px]"
+        className="my-[55px] h-[240px] w-[240px]"
       >
         <MotionSquareShadeCard
-          className="absolute aspect-square rounded-[36px] bg-cool-neutral-7 opacity-35"
+          className="absolute aspect-square rounded-[36px] bg-cool-neutral-7 opacity-35 will-change-transform"
           color={color}
           width={240}
           height={240}
@@ -50,6 +50,7 @@ export default function AnimatedSpreadCard({
           }}
         />
         <MotionSquareMonsterCard
+          className="will-change-transform"
           name={name}
           color={color}
           width={240}

--- a/src/app/(route)/(monster)/monster/[slug]/result/page.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/result/page.tsx
@@ -2,10 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
-import { useState, useEffect } from 'react';
-
 import { LayoutGroup } from 'framer-motion';
-import { find } from 'lodash';
 
 import CharacterCanvas from '@components/CharacterCanvas';
 import Button from '@components/common/Button';
@@ -13,10 +10,9 @@ import Button from '@components/common/Button';
 import useModal from '@hooks/useModal';
 
 import generateShareUrl from '@utils/client/generate-share-url';
+import cn from '@utils/cn';
 
 import { useMonster } from '@api/monster/query/hooks';
-import { GetMonsterResponse } from '@api/monster/types';
-import { DecorationType, Emotion } from '@api/schema/monster';
 
 import { GuideMessage, AnimatedSpreadCard } from './components';
 import ShareModal from '../../../../../components/modals/ShareModal';
@@ -29,17 +25,11 @@ export default function MonsterResultPage({
   const { slug: monsterId } = params;
 
   const router = useRouter();
-  const [monster, setMonster] = useState<GetMonsterResponse | null>();
 
-  const { error, isError, status, fetchStatus, data } = useMonster(monsterId);
+  const { error, isError, isFetching, status, fetchStatus, data } =
+    useMonster(monsterId);
 
   const SHARE_URL = generateShareUrl(monsterId) ?? '';
-
-  useEffect(() => {
-    if (data) {
-      setMonster(data);
-    }
-  }, [data]);
 
   const handleDefer = () => {
     router.push('/');
@@ -61,7 +51,9 @@ export default function MonsterResultPage({
     return <div>No monster ID provided in the URL</div>;
   }
 
-  if (!monster) {
+  if (!data) {
+    if (isFetching) return <>fetching...</>;
+
     // [TODO] 몬스터 생성 오류 OR 임의적 접근
     return <div>Loading...</div>;
   }
@@ -70,34 +62,28 @@ export default function MonsterResultPage({
     console.error('error :: ', error);
   }
 
-  // TODO 개선
-  const color =
-    find(monster.monsterDecorations, {
-      decorationType: DecorationType.BACKGROUND_COLOR,
-    })?.decorationValue || '';
-
-  const CHARACTER_TYPE = monster.emotion === Emotion.ANGER ? 'mad' : 'sad';
-  const CHARACTER_ITEMS = monster.monsterDecorations
-    .map(
-      (deco) =>
-        deco.decorationType !== DecorationType.BACKGROUND_COLOR &&
-        deco.decorationValue.toLowerCase(),
-    )
-    .filter(Boolean) as string[];
+  const { BACKGROUND_COLOR, ...REST_DECOS } = data.decorations;
 
   return (
-    <div className="mx-auto flex !h-dvh h-full w-full items-center justify-center bg-gradient-to-b from-cool-neutral-5 to-[#253047]">
+    <div className="mx-auto flex h-dvh w-full items-center justify-center bg-gradient-to-b from-cool-neutral-5 to-[#253047]">
       <div className="flex h-[573px] max-h-dvh flex-col items-center justify-between py-[20px]">
-        {fetchStatus === 'fetching' && <>fetching...</>}
         {status === 'success' && fetchStatus === 'idle' && (
           <>
             <LayoutGroup>
               <GuideMessage />
-              <AnimatedSpreadCard name={monster.monsterName} color={color}>
+              <AnimatedSpreadCard
+                name={data.monsterName}
+                // [TODO] BACKGROUND_COLOR 필수 여부 확인 필요
+                color={BACKGROUND_COLOR ?? ''}
+              >
                 <CharacterCanvas
-                  type={CHARACTER_TYPE}
-                  items={CHARACTER_ITEMS}
-                  className="mb-[30px] h-full w-full"
+                  type={data.type}
+                  items={Object.values(REST_DECOS)}
+                  className={cn(
+                    'h-full w-full',
+                    data.type === 'mad' && ' -translate-y-[20px]',
+                    data.type === 'sad' && ' -translate-y-[10px]',
+                  )}
                 />
               </AnimatedSpreadCard>
             </LayoutGroup>
@@ -111,7 +97,6 @@ export default function MonsterResultPage({
             </footer>
           </>
         )}
-
         {error && <>error</>}
       </div>
     </div>

--- a/src/app/(route)/(monster)/monster/[slug]/share/components/DoneStep.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/components/DoneStep.tsx
@@ -14,77 +14,79 @@ export default function DoneStep({ goNext }: DoneStepProps) {
   const visible = { opacity: 1, y: 0, transition: { duration: 0.5 } };
 
   return (
-    <motion.div
-      className="flex h-full w-full flex-col items-center"
-      initial="hidden"
-      animate="visible"
-      variants={{ visible: { transition: { staggerChildren: 0.1 } } }}
-    >
-      <div className="m-auto">
-        <motion.div
-          className="mx-auto mb-20 w-max"
-          animate={{
-            rotateY: 180,
-            transition: {
-              duration: 0.6,
-            },
-          }}
-          variants={{
-            hidden: { opacity: 0, y: -24 },
-            visible,
-          }}
-        >
-          <Image
-            src="/images/heart0000.png"
-            width={108}
-            height={108}
-            alt="하트"
-          />
-        </motion.div>
-        <motion.div>
-          <BaseText
-            color="strong"
-            component="h3"
-            variant="heading-1"
-            weight="semibold"
-            align="center"
-          >
-            <motion.span
-              className="block"
-              variants={{
-                hidden: { opacity: 0, y: 10 },
-                visible,
-              }}
-            >
-              친구에게 나의 응원이
-            </motion.span>
-            <motion.span
-              className="block"
-              variants={{
-                hidden: { opacity: 0, y: 10 },
-                visible,
-              }}
-            >
-              전송 되었어요!
-            </motion.span>
-          </BaseText>
-        </motion.div>
-      </div>
-      <motion.nav
-        variants={{
-          hidden: { opacity: 0, y: 10 },
-          visible: { ...visible, transition: { duration: 0.8 } },
-        }}
+    <section className="flex h-full w-full flex-col items-center justify-between gap-[28px] bg-gradient-to-b from-cool-neutral-5 to-[#253047] p-[20px] pt-[36px]">
+      <motion.div
+        className="flex h-full w-full flex-col items-center"
+        initial="hidden"
+        animate="visible"
+        variants={{ visible: { transition: { staggerChildren: 0.1 } } }}
       >
-        <Button
-          className="mx-auto"
-          variant="primary"
-          size="large"
-          onClick={goNext}
+        <div className="m-auto">
+          <motion.div
+            className="mx-auto mb-20 w-max"
+            animate={{
+              rotateY: 180,
+              transition: {
+                duration: 0.6,
+              },
+            }}
+            variants={{
+              hidden: { opacity: 0, y: -24 },
+              visible,
+            }}
+          >
+            <Image
+              src="/images/heart0000.png"
+              width={108}
+              height={108}
+              alt="하트"
+            />
+          </motion.div>
+          <motion.div>
+            <BaseText
+              color="strong"
+              component="h3"
+              variant="heading-1"
+              weight="semibold"
+              align="center"
+            >
+              <motion.span
+                className="block"
+                variants={{
+                  hidden: { opacity: 0, y: 10 },
+                  visible,
+                }}
+              >
+                친구에게 나의 응원이
+              </motion.span>
+              <motion.span
+                className="block"
+                variants={{
+                  hidden: { opacity: 0, y: 10 },
+                  visible,
+                }}
+              >
+                전송 되었어요!
+              </motion.span>
+            </BaseText>
+          </motion.div>
+        </div>
+        <motion.nav
+          variants={{
+            hidden: { opacity: 0, y: 10 },
+            visible: { ...visible, transition: { duration: 0.8 } },
+          }}
         >
-          나도 퇴사몬 만들어보기
-        </Button>
-      </motion.nav>
-    </motion.div>
+          <Button
+            className="mx-auto"
+            variant="primary"
+            size="large"
+            onClick={goNext}
+          >
+            나도 퇴사몬 만들어보기
+          </Button>
+        </motion.nav>
+      </motion.div>
+    </section>
   );
 }

--- a/src/app/(route)/(monster)/monster/[slug]/share/components/EncouragementStep.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/components/EncouragementStep.tsx
@@ -39,8 +39,8 @@ export default function EncouragementStep({
   }, [isSubmitSuccessful, reset]);
 
   return (
-    <>
-      <div className="h-full w-full">
+    <section className="flex h-full w-full flex-col items-center justify-between gap-[28px] bg-gradient-to-b from-cool-neutral-5 to-[#253047] p-[20px] pt-[36px]">
+      <div className="max-w-dvw h-full w-[375px] w-full">
         <BaseText
           className="align-left mb-[40px]"
           component="h3"
@@ -71,6 +71,6 @@ export default function EncouragementStep({
           전송하기
         </Button>
       </nav>
-    </>
+    </section>
   );
 }

--- a/src/app/(route)/(monster)/monster/[slug]/share/components/InteractionStep.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/components/InteractionStep.tsx
@@ -5,9 +5,8 @@ import { ErrorBoundary } from 'react-error-boundary';
 
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
-import LogoSVG from '@public/icons/logo.svg';
-
 import Button from '@components/common/Button';
+import Header from '@components/Header';
 
 import SharedMonsterFlipCard from 'src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard';
 import SharedMonsterFlipCardSkeleton from 'src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/Skeleton';
@@ -28,24 +27,25 @@ export default function InteractionStep({
   const { clear } = useContext(GuestContext);
 
   return (
-    <>
-      <header className="flex w-full items-center justify-center">
-        <LogoSVG width={115} height={20} />
-      </header>
-      <QueryErrorResetBoundary>
-        {({ reset }) => (
-          <ErrorBoundary FallbackComponent={Error} onReset={reset}>
-            <Suspense fallback={<SharedMonsterFlipCardSkeleton />}>
-              <SharedMonsterFlipCard
-                clear={clear}
-                monsterId={slug}
-                onComplete={onCompeleteInteraction}
-              />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-      </QueryErrorResetBoundary>
-
+    <section className="flex h-full w-full flex-col items-center justify-between gap-[28px] bg-gradient-to-b from-cool-neutral-5 to-[#253047] px-[20px] pb-[20px]">
+      <div className="h-dvh">
+        <Header className="mb-[20px] justify-center">
+          <Header.Logo size={32} />
+        </Header>
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary FallbackComponent={Error} onReset={reset}>
+              <Suspense fallback={<SharedMonsterFlipCardSkeleton />}>
+                <SharedMonsterFlipCard
+                  clear={clear}
+                  monsterId={slug}
+                  onComplete={onCompeleteInteraction}
+                />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      </div>
       <nav>
         <Button
           size="large"
@@ -56,6 +56,6 @@ export default function InteractionStep({
           응원메세지 작성하기
         </Button>
       </nav>
-    </>
+    </section>
   );
 }

--- a/src/app/(route)/(monster)/monster/[slug]/share/layout.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/layout.tsx
@@ -13,12 +13,10 @@ function ShareLayout({ children }: Props) {
     <main
       style={{ touchAction: 'auto' }}
       className={cn(
-        'relative m-auto box-border	flex h-dvh w-full max-w-[414px] flex-col items-center overflow-auto overscroll-none p-20',
+        'relative m-auto box-border	flex h-dvh w-full flex-col items-center overflow-hidden overscroll-none',
       )}
     >
-      <section className="flex h-full w-full flex-col items-center justify-between gap-[28px]">
-        <GuestProvider>{children}</GuestProvider>
-      </section>
+      <GuestProvider>{children}</GuestProvider>
     </main>
   );
 }

--- a/src/app/(route)/(monster)/page.tsx
+++ b/src/app/(route)/(monster)/page.tsx
@@ -1,23 +1,35 @@
+import { ErrorBoundary } from 'react-error-boundary';
+
 import HydrateWithAuth from '@providers/HydrationAuthBoudary';
 
 import { getRefMonster } from '@api/monster';
+import MonsterQueryFactory from '@api/monster/query/factory';
 
+import RefMonsterFlipCard from './component/cards/RefMonsterFlipCard';
+import MainHeader from './component/MainHeader';
 import MessageBottomSheet from './component/Message/MessageBottomSheet';
 
 async function Home() {
   const messageQueries = [
     {
-      queryKey: ['my-monster'],
+      ...MonsterQueryFactory.reference,
       queryFn: getRefMonster,
     },
   ];
 
   return (
-    <div>
+    <section>
       <HydrateWithAuth queries={messageQueries}>
+        <MainHeader />
+        <div className="flex h-[calc(100vh-211px)] w-screen items-center px-32">
+          {/* [TODO] ErrorBoundary 개선 */}
+          <ErrorBoundary fallback={<>error</>}>
+            <RefMonsterFlipCard />
+          </ErrorBoundary>
+        </div>
         <MessageBottomSheet />
       </HydrateWithAuth>
-    </div>
+    </section>
   );
 }
 

--- a/src/app/api/interaction/query/hooks.ts
+++ b/src/app/api/interaction/query/hooks.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { merge } from 'lodash';
+
+import { getQueryClient } from '@utils/query/get-query-client';
+
+import MonsterQueryFactory from '@api/monster/query/factory';
+
+import { updateInteractionCount } from '..';
+
+export const useUpdateInteraction = (id: string) => {
+  const queryClient = getQueryClient();
+
+  return useMutation({
+    mutationKey: ['updateInteractionCount'],
+    mutationFn: (interactionCount: number) =>
+      updateInteractionCount({
+        monsterId: id,
+        interactionCount,
+      }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        MonsterQueryFactory.reference.queryKey,
+        (oldData: object) => merge(oldData, data),
+      );
+    },
+    onError(error) {
+      console.log(error);
+    },
+  });
+};

--- a/src/app/api/monster/query/factory.ts
+++ b/src/app/api/monster/query/factory.ts
@@ -6,12 +6,12 @@ import {
 import { getRefMonster, getMonsterById, getMonsterList } from '..';
 
 const MonsterQueryFactory = createQueryKeys('monster', {
-  reference: () => ({
-    queryKey: ['reference'], // output: ['monster', 'reference']
+  reference: {
+    queryKey: null, // output: ['monster', 'reference']
     queryFn: getRefMonster,
-  }),
+  },
   detail: (id: string) => ({
-    queryKey: [id], // output: ['monster', id]
+    queryKey: [id], // output: ['monster', 'detail', id]
     queryFn: () => getMonsterById(id),
   }),
   list: (filters) => ({

--- a/src/app/api/monster/query/hooks.ts
+++ b/src/app/api/monster/query/hooks.ts
@@ -32,7 +32,7 @@ export const useModifyMonster = (id: string) => {
     mutationFn: (data) => modifyMonster(id, data),
     onSuccess: (_, variables) => {
       queryClient.setQueryData(
-        MonsterQueryFactory.detail(id).queryKey,
+        MonsterQueryFactory.reference.queryKey,
         (oldData: object) =>
           merge(oldData, {
             data: variables,

--- a/src/app/api/monster/query/hooks.ts
+++ b/src/app/api/monster/query/hooks.ts
@@ -3,6 +3,8 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { merge } from 'lodash';
 
+import { Adapter } from '@utils/client/adapter';
+import transformMonster from '@utils/client/transform-monster';
 import { getQueryClient } from '@utils/query/get-query-client';
 
 import { modifyMonster } from '..';
@@ -14,12 +16,12 @@ export const useMonster = (id: string) => {
   return useQuery<
     AxiosResponse<GetMonsterResponse>,
     AxiosError,
-    GetMonsterResponse,
+    ReturnType<typeof transformMonster<GetMonsterResponse>>,
     MonsterKeys['detail']['queryKey']
   >({
     ...MonsterQueryFactory.detail(id),
     enabled: !!id,
-    select: (data) => data.data,
+    select: (data) => Adapter.from(data.data).to(transformMonster),
   });
 };
 

--- a/src/app/components/CharacterCanvas.tsx
+++ b/src/app/components/CharacterCanvas.tsx
@@ -20,7 +20,7 @@ export default function CharacterCanvas({
   items = [],
   ...rest
 }: CharacterCanvasProps) {
-  const canvasRef = useCanvas(480, 480); // X2
+  const canvasRef = useCanvas(480, 720); // X2
 
   const fillBackground = (ctx: CanvasRenderingContext2D, fillStyle: string) => {
     ctx.fillStyle = fillStyle;
@@ -51,10 +51,14 @@ export default function CharacterCanvas({
 
     images.forEach((image) => {
       const scale = Math.min(width / image.width, height / image.height);
+
       const dw = image.width * scale;
       const dh = image.height * scale;
 
-      ctx.drawImage(image, 0, 0, dw, dh);
+      console.log('dw :: ', dw);
+      console.log('dh :: ', dh);
+
+      ctx.drawImage(image, (width - dw) / 2, (height - dh) / 2, dw, dh);
     });
   };
 

--- a/src/app/components/CharacterCanvas.tsx
+++ b/src/app/components/CharacterCanvas.tsx
@@ -43,23 +43,22 @@ export default function CharacterCanvas({
     fillStyle?: string,
   ) => {
     const { width, height } = ctx.canvas;
+    try {
+      const images = await Promise.all(sources.map((src) => loadImage(src)));
+      ctx.clearRect(0, 0, width, height);
 
-    const images = await Promise.all(sources.map((src) => loadImage(src)));
-    ctx.clearRect(0, 0, width, height);
+      if (fillStyle) fillBackground(ctx, fillStyle);
 
-    if (fillStyle) fillBackground(ctx, fillStyle);
+      images.forEach((image) => {
+        const scale = Math.min(width / image.width, height / image.height);
+        const dw = image.width * scale;
+        const dh = image.height * scale;
 
-    images.forEach((image) => {
-      const scale = Math.min(width / image.width, height / image.height);
-
-      const dw = image.width * scale;
-      const dh = image.height * scale;
-
-      console.log('dw :: ', dw);
-      console.log('dh :: ', dh);
-
-      ctx.drawImage(image, (width - dw) / 2, (height - dh) / 2, dw, dh);
-    });
+        ctx.drawImage(image, (width - dw) / 2, (height - dh) / 2, dw, dh);
+      });
+    } catch (error) {
+      console.error('Error loading images:', error);
+    }
   };
 
   useEffect(() => {

--- a/src/app/components/CounterBox/index.tsx
+++ b/src/app/components/CounterBox/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, PropsWithChildren, SetStateAction, useMemo } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 
 import { atom, useAtom } from 'jotai';
 import { atomWithReset, useResetAtom } from 'jotai/utils';
@@ -14,7 +14,7 @@ export type CounterBoxProps = PropsWithChildren & {
   step?: number;
   delay?: number;
   helperText?: string;
-  onCount: Dispatch<SetStateAction<number>>;
+  onCount: (count: number) => void;
   onComplete?: () => void;
   onMouseDown?: () => void;
   onMouseUp?: () => void;
@@ -47,7 +47,7 @@ export default function CounterBox({
   const debouncedCount = useMemo(
     () =>
       debounce((clickCount) => {
-        onCount((prev) => Math.min(prev + clickCount * step, endAt));
+        onCount(clickCount * step);
         resetAtom();
       }, delay),
     [endAt, step, delay, onCount, resetAtom],
@@ -65,6 +65,7 @@ export default function CounterBox({
   return (
     <>
       <motion.div
+        className="h-full w-full"
         initial="hidden"
         animate="visible"
         variants={{
@@ -78,7 +79,7 @@ export default function CounterBox({
         }}
       >
         <motion.button
-          className="pointer absolute bottom-0 left-0 right-0 top-0 m-auto h-max w-max"
+          className="pointer m-auto h-full w-full"
           whileHover={{ scale: 1.15 }}
           whileTap={{
             scale: 0.8,

--- a/src/app/components/Header/HeaderIconButton.tsx
+++ b/src/app/components/Header/HeaderIconButton.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import IconButton, {
+  IconButtonProps,
+} from '@components/common/Button/IconButton';
+
+type HeaderIconButtonProps = Omit<IconButtonProps, 'size'>;
+
+export default function HeaderIconButton({ ...props }: HeaderIconButtonProps) {
+  return <IconButton size={24} {...props} />;
+}

--- a/src/app/components/Header/HeaderLinkLogo.tsx
+++ b/src/app/components/Header/HeaderLinkLogo.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+import { ExtractProps } from '@type/util';
+
+import HeaderLogo from './HeaderLogo';
+
+type HeaderLinkLogoProps = ExtractProps<typeof HeaderLogo> &
+  ExtractProps<typeof Link>;
+
+export default function HeaderLinkLogo({
+  size,
+  href,
+  ...rest
+}: HeaderLinkLogoProps) {
+  return (
+    <Link href={href} passHref {...rest}>
+      <HeaderLogo size={size} />
+    </Link>
+  );
+}

--- a/src/app/components/Header/HeaderLogo.tsx
+++ b/src/app/components/Header/HeaderLogo.tsx
@@ -1,0 +1,22 @@
+import { VariantProps, cva } from 'class-variance-authority';
+
+import LogoSVG from '@public/icons/logo.svg';
+
+const logoStyles = cva('m-auto', {
+  variants: {
+    size: {
+      24: 'w-[60px] h-[24px]',
+      32: 'w-[80px] h-[32px]',
+    },
+  },
+});
+
+type HeaderLogoProps = VariantProps<typeof logoStyles>;
+
+export default function HeaderLogo({ size }: HeaderLogoProps) {
+  return (
+    <div className={logoStyles({ size })}>
+      <LogoSVG />
+    </div>
+  );
+}

--- a/src/app/components/Header/HeaderTitle.tsx
+++ b/src/app/components/Header/HeaderTitle.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+
+import BaseText from '@components/common/Text/BaseText';
+
+type HeaderTitleProps = PropsWithChildren;
+
+export default function HeaderTitle({ children }: HeaderTitleProps) {
+  return (
+    <BaseText
+      component="h3"
+      variant="headline-1"
+      weight="semibold"
+      color="normal"
+    >
+      {children}
+    </BaseText>
+  );
+}

--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -1,0 +1,29 @@
+import { ComponentProps } from 'react';
+
+import cn from '@utils/cn';
+
+import HeaderIconButton from './HeaderIconButton';
+import HeaderLinkLogo from './HeaderLinkLogo';
+import HeaderLogo from './HeaderLogo';
+import HeaderTitle from './HeaderTitle';
+
+type HeaderProps = ComponentProps<'header'>;
+
+export default function Header({ className, children, ...rest }: HeaderProps) {
+  return (
+    <header
+      className={cn(
+        'flex w-full items-center justify-between p-[12px]',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </header>
+  );
+}
+
+Header.Title = HeaderTitle;
+Header.Logo = HeaderLogo;
+Header.LinkLogo = HeaderLinkLogo;
+Header.IconButton = HeaderIconButton;

--- a/src/app/components/ProgressBar/index.tsx
+++ b/src/app/components/ProgressBar/index.tsx
@@ -45,7 +45,7 @@ export default function ProgressBar({
           component="span"
           variant="label-1"
           weight="semibold"
-          className="w-2/12 text-right"
+          className="pointer-event-none w-2/12 select-none text-right"
         >
           {label === 'percent' && `${percent.toFixed(fractionDigits)}%`}
           {label === 'numeric' && `${value}/${max}`}

--- a/src/app/components/cards/MonsterFlipCard/CardActionArea.tsx
+++ b/src/app/components/cards/MonsterFlipCard/CardActionArea.tsx
@@ -11,7 +11,10 @@ export default function CardActionArea({
 }: CardActionAreaProps) {
   return (
     <div
-      className={cn('relative h-full w-full rounded-t-[28px] p-16', className)}
+      className={cn(
+        'relative h-full w-full select-none rounded-t-[28px] p-16',
+        className,
+      )}
       {...rest}
     >
       {children}

--- a/src/app/components/cards/MonsterFlipCard/CardContent.tsx
+++ b/src/app/components/cards/MonsterFlipCard/CardContent.tsx
@@ -1,10 +1,22 @@
-import { PropsWithChildren } from 'react';
+import { ComponentProps } from 'react';
 
-type CardContentProps = PropsWithChildren;
+import cn from '@utils/cn';
 
-export default function CardContent({ children }: CardContentProps) {
+type CardContentProps = ComponentProps<'div'>;
+
+export default function CardContent({
+  className,
+  children,
+  ...rest
+}: CardContentProps) {
   return (
-    <div className="flex h-[88px] w-full flex-col gap-12 rounded-b-[28px] bg-cool-neutral-7 px-20 py-12">
+    <div
+      className={cn(
+        'flex h-[88px] w-full flex-col gap-12 rounded-b-[28px] bg-cool-neutral-7 px-20 py-12 outline outline-cool-neutral-7',
+        className,
+      )}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/app/components/common/Button/IconButton.tsx
+++ b/src/app/components/common/Button/IconButton.tsx
@@ -1,0 +1,28 @@
+import Icon from '@components/common/Icon';
+
+import cn from '@utils/cn';
+
+import { ExtractProps } from '@type/util';
+
+import Button from '.';
+
+export type IconButtonProps = Omit<ExtractProps<typeof Button>, 'size'> &
+  Pick<ExtractProps<typeof Icon>, 'name' | 'size' | 'stroke'>;
+
+export default function IconButton({
+  className,
+  name,
+  size,
+  stroke,
+  ...rest
+}: IconButtonProps) {
+  return (
+    <Button
+      className={cn('h-[24px] w-[24px] p-0', className)}
+      variant="ghost"
+      {...rest}
+    >
+      <Icon name={name} size={size} stroke={stroke} />
+    </Button>
+  );
+}

--- a/src/app/components/common/Icon/index.tsx
+++ b/src/app/components/common/Icon/index.tsx
@@ -1,6 +1,30 @@
 import { cva, VariantProps } from 'class-variance-authority';
 
+import ArrowBackSVG from '@public/icons/arrow-back.svg';
+import DownloadSVG from '@public/icons/download.svg';
+import EditSVG from '@public/icons/edit.svg';
+import EllipsisSVG from '@public/icons/ellipsis.svg';
+import HamburgerSVG from '@public/icons/hamburger.svg';
+import HeartSVG from '@public/icons/heart.svg';
+import InfoSVG from '@public/icons/info.svg';
+import RefreshSVG from '@public/icons/refresh.svg';
+import ShareSVG from '@public/icons/share.svg';
+import SpinSVG from '@public/icons/spin.svg';
+
 import cn from '@utils/cn';
+
+export const IconMap = {
+  'arrow-back': ArrowBackSVG,
+  download: DownloadSVG,
+  edit: EditSVG,
+  ellipsis: EllipsisSVG,
+  hamburger: HamburgerSVG,
+  heart: HeartSVG,
+  information: InfoSVG,
+  refresh: RefreshSVG,
+  share: ShareSVG,
+  spin: SpinSVG,
+} as const;
 
 export const iconStyles = cva(
   ['inline-flex', 'items-center', 'justify-center'],
@@ -46,13 +70,13 @@ export const iconStyles = cva(
   },
 );
 
-export type IconProps<T extends React.ElementType> = VariantProps<
-  typeof iconStyles
-> &
-  React.ComponentPropsWithoutRef<T> & {
-    children: React.ReactElement<React.SVGProps<SVGSVGElement>>;
-    component?: T;
-  };
+export type IconProps<T extends React.ElementType = 'span'> =
+  React.ComponentPropsWithoutRef<T> &
+    VariantProps<typeof iconStyles> & {
+      component?: T;
+      children?: React.ReactElement<React.SVGProps<SVGSVGElement>>;
+      name?: keyof typeof IconMap;
+    };
 
 export default function Icon<T extends React.ElementType = 'span'>({
   component,
@@ -60,12 +84,14 @@ export default function Icon<T extends React.ElementType = 'span'>({
   children,
   size,
   stroke,
+  name,
 }: IconProps<T>) {
   const Component: React.ElementType = component || 'span';
 
   return (
     <Component className={cn(iconStyles({ size, stroke }), className)}>
-      {children}
+      {name && IconMap[name]()}
+      {!name && children}
     </Component>
   );
 }

--- a/src/app/utils/get-image-path.ts
+++ b/src/app/utils/get-image-path.ts
@@ -77,12 +77,13 @@ function getImagePath(
 
 function getImagePath(type: keyof DirPath, name?: string): string {
   if (type !== 'base' && name) {
-    if (hasIn(imagePath, [type, name])) {
-      return get(imagePath, [type, name])();
+    if (hasIn(imagePath, [type, name.toLowerCase()])) {
+      return get(imagePath, [type, name.toLowerCase()])();
     }
+    return '';
   }
 
-  return `/${dirPath.base.join('/')}`;
+  return `${dirPath.base.join('/')}`;
 }
 
 export default getImagePath;


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 :
- 관련 Figma : 

### ⚙️ Changes

홈 화면에 Header, RefCard 컴포넌트를 추가하였습니다. 

**Header 컴포넌트 추가**
  메인 Header 컴포넌트는 IconButton, Logo, LinkLogo, Title 컴포넌트를 서브 컴포넌트로 가집니다. 

**IconButton 컴포넌트 추가 및 Icon 컴포넌트 개선**
  - IconButton 컴포넌트 추가하였습니다. (`24*24` 고정)
  - Icon 컴포넌트의 경우 `name` prop을 통하여 SVG 아이콘을 사용할 수 있도록  개선하였습니다.
  
**RefMonsterFlipCard 컴포넌트 개선** 
  - ActionArea 내부 컴포넌트를 인터랙션 및 업데이트가 가능하도록 MonsterCounterBox 컴포넌트로 변경하였습니다.
  - 카드 스와이프 시에 플립이 가능하도록 추가하였습니다. 
  - useUpdateInteraction 쿼리 훅을 추가하였습니다. 
  
**CharacterCanvas 컴포넌트 개선** 
  - `drawImages()` 내부 try-catch 추가하였습니다. 
  - `drawImages()` 내부 이미지가 중앙에 정렬될 수 있도록 좌표를 수정하였습니다. 
  
**MonsterCounterBox 컴포넌트 개선** 
  - 트리 내부 이펙트 캔버스를 캐릭터 캔버스와 분리하여 캐릭터 바운스 애니메이션에 영향을 받지않도록 개선하였습니다. 
  - onCount(debounced 콜백)시에 `addConfetti()`를 호출하도록 개선하였습니다. 
  - CounterBox 컴포넌트의 경우 onCount 타입을 유연하게 수정하였습니다.
  

