### PR TITLE
useBottomSheet 훅 동작 수정 

### DIFF
--- a/src/app/(route)/(auth)/signin/page.tsx
+++ b/src/app/(route)/(auth)/signin/page.tsx
@@ -3,7 +3,7 @@ import KakaoLoginBtn from './components/kakao-login-btn';
 
 function SignIn() {
   return (
-    <div className="flex w-full flex-1 flex-col p-20">
+    <div className="flex w-full flex-1 flex-col justify-end p-20">
       <div>
         <CsrfTokenInitializer>
           <KakaoLoginBtn />

--- a/src/app/(route)/(monster)/component/MenuDrawer/Section.tsx
+++ b/src/app/(route)/(monster)/component/MenuDrawer/Section.tsx
@@ -1,15 +1,23 @@
 import Link from 'next/link';
 
-import type { ComponentProps, ComponentPropsWithoutRef } from 'react';
+import type {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  ElementType,
+} from 'react';
 
 import ArrowSVG from '@public/icons/arrow-back.svg';
+
+import Spinner from '@components/Spinner';
 
 import cn from '@utils/cn';
 
 type SectionProps = ComponentProps<'section'>;
+type SectionCommonItemProps<T extends ElementType> =
+  ComponentPropsWithoutRef<T> & { loading?: boolean };
 type SectionItemProps =
-  | (ComponentPropsWithoutRef<'a'> & { component: 'a' })
-  | (ComponentPropsWithoutRef<'button'> & { component: 'button' });
+  | (SectionCommonItemProps<'a'> & { component: 'a' })
+  | (SectionCommonItemProps<'button'> & { component: 'button' });
 
 function Section({ children, className, ...restProps }: SectionProps) {
   return (
@@ -26,6 +34,7 @@ function SecionItem({
   children,
   component,
   className,
+  loading = false,
   ...restProps
 }: SectionItemProps) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,14 +45,18 @@ function SecionItem({
       className={cn(
         'bg-[#70737C1F]',
         'w-full px-24 py-20',
-        'flex items-center justify-between ',
+        'flex items-center justify-between',
+        { 'pointer-events-none': loading },
         className,
       )}
       {...restProps}
     >
       {children}
 
-      <ArrowSVG className="rotate-180 scale-[60%]" color="#C2C4C8E0" />
+      {loading && <Spinner />}
+      {!loading && (
+        <ArrowSVG className="rotate-180 scale-[60%]" color="#C2C4C8E0" />
+      )}
     </Component>
   );
 }

--- a/src/app/(route)/(monster)/component/MenuDrawer/index.tsx
+++ b/src/app/(route)/(monster)/component/MenuDrawer/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useReducer } from 'react';
+
 import ArrowBackSVG from '@public/icons/arrow-back.svg';
 
 import BaseText from '@components/common/Text/BaseText';
@@ -10,10 +12,31 @@ import signOut from 'src/app/(route)/(auth)/signin/utils/signout';
 
 import Section from './Section';
 
+type LoadginType = 'signout';
+type LoadingState = Record<LoadginType, boolean>;
+type LoadingReducer = (
+  state: LoadingState,
+  payload: LoadingState,
+) => LoadingState;
+
 function Menu() {
   const { closeDrawer } = useDrawer();
 
-  const handleSignout = () => signOut({ callbackUrl: '/signin' });
+  const [{ signout }, updater] = useReducer<LoadingReducer>(
+    (state, payload) => {
+      return { ...state, ...payload };
+    },
+    {
+      signout: false,
+    },
+  );
+
+  const handleSignout = () => {
+    updater({ signout: true });
+    signOut({ callbackUrl: '/signin' }).finally(() => {
+      updater({ signout: false });
+    });
+  };
 
   return (
     <aside className="full-height full-height-ios bg-black px-20">
@@ -43,7 +66,12 @@ function Menu() {
         <Section.Item component="a" href="/">
           프로필 수정
         </Section.Item>
-        <Section.Item type="button" component="button" onClick={handleSignout}>
+        <Section.Item
+          type="button"
+          component="button"
+          loading={signout}
+          onClick={handleSignout}
+        >
           로그아웃
         </Section.Item>
       </Section>

--- a/src/app/(route)/(monster)/component/Message/MessageList.tsx
+++ b/src/app/(route)/(monster)/component/Message/MessageList.tsx
@@ -43,12 +43,12 @@ function MessageList() {
   } = MessageQueryFactory;
 
   const {
-    data: { messageList, totalElements },
+    data: { messageList, uncheckedMessageCount },
   } = useSuspenseInfiniteQuery({
     retry: 1,
+    staleTime: 0,
     initialPageParam: 1,
     queryKey: key({ monsterId: `${monsterId}` }),
-    staleTime: 0,
     queryFn: ({ pageParam = 1 }) =>
       fetcher({ monsterId: Number(monsterId), page: pageParam }),
     getNextPageParam: ({ nextPage }: LastPage) => {
@@ -60,12 +60,13 @@ function MessageList() {
         .flat()
         .sort((a, b) => Number(a.checked) - Number(b.checked)),
       totalElements: pages.pages[0].result.totalElements,
+      uncheckedMessageCount: pages.pages[0].result.uncheckedMessageCount,
     }),
   });
 
   useEffect(() => {
-    setTotalElements(totalElements);
-  }, [totalElements]);
+    setTotalElements(uncheckedMessageCount);
+  }, [uncheckedMessageCount]);
 
   const handleClick = (message: (typeof messageList)[number]) => {
     openModal(() => (

--- a/src/app/api/message/list.ts
+++ b/src/app/api/message/list.ts
@@ -22,14 +22,14 @@ const getNextMessageList = async ({
   page: number;
 }) => {
   const {
-    data: { content, totalElements },
+    data: { content, totalElements, uncheckedMessageCount },
   } = await getMessageList({ monsterId, page });
 
   const nextPage =
     content.length > 0 && content.length >= PAGE_SIZE ? page + 1 : undefined;
 
   return {
-    result: { list: content, totalElements },
+    result: { list: content, totalElements, uncheckedMessageCount },
     nextPage,
     isLast: !nextPage,
   };

--- a/src/app/api/message/type.ts
+++ b/src/app/api/message/type.ts
@@ -14,6 +14,8 @@ export type MessageListResponse = {
   size: number;
   page: number;
   totalElements: number;
+  checkedMessageCount: number;
+  uncheckedMessageCount: number;
 };
 
 export type QueryKeysProps = {


### PR DESCRIPTION
### ⚙️ Changes

useBottomSheet 에서 터치로 이동할 수 있는 영역을 3단계로 나눠서, top, bottom. max_bottom 으로 세분화 했습니다. 
- 홈 화면에서 bottomsheet 와 flip 카드가 겹치는 이슈가 있어 더 세분화 했습니다. 

message bottomsheet 내 노출할 메시지 카운트를 읽지 않은 메시지 기준으로 나눴습니다. 

