### PR TITLE
홈 페이지 새로운 몬스터 만들기 모달 컴포넌트 구현

### DIFF
--- a/src/app/(route)/(monster)/component/cards/RefMonsterFlipCard/index.tsx
+++ b/src/app/(route)/(monster)/component/cards/RefMonsterFlipCard/index.tsx
@@ -16,7 +16,10 @@ import { AxiosError } from 'axios';
 import MonsterFlipCard from '@components/cards/MonsterFlipCard';
 import Button from '@components/common/Button';
 import BaseText from '@components/common/Text/BaseText';
+import MonsterCreationModal from '@components/modals/MonsterCreationModal';
 import ProgressBar from '@components/ProgressBar';
+
+import useModal from '@hooks/useModal';
 
 import { Adapter } from '@utils/client/adapter';
 import transformMonster from '@utils/client/transform-monster';
@@ -47,6 +50,10 @@ export default function RefMonsterFlipCard() {
   });
 
   const { mutate: updateCount } = useUpdateInteraction(monster.monsterId);
+
+  const { openModal, closeModal } = useModal(() => (
+    <MonsterCreationModal onClose={closeModal} />
+  ));
 
   const [clear, setClear] = useState(
     () => monster.currentInteractionCount >= monster.interactionCount,
@@ -128,6 +135,18 @@ export default function RefMonsterFlipCard() {
             setClear(true);
           }}
         />
+        {clear && (
+          <div className="absolute bottom-0 left-0 right-0 w-full px-[16px] py-[12px]">
+            <Button
+              className="label-1-medium mx-auto w-full bg-[#17171985] text-cool-neutral-99"
+              size="small"
+              variant="secondary"
+              onClick={() => openModal()}
+            >
+              새로운 퇴사몬 만들기
+            </Button>
+          </div>
+        )}
       </MonsterFlipCard.ActionArea>
       <MonsterFlipCard.Content
         onMouseDown={handleMouseDown}

--- a/src/app/components/modals/MonsterCreationModal.tsx
+++ b/src/app/components/modals/MonsterCreationModal.tsx
@@ -1,0 +1,48 @@
+import { useRouter } from 'next/navigation';
+
+// import toast from 'react-hot-toast';
+
+import { Modal } from '@components/common/Modal';
+
+type MonsterCreationModalProps = {
+  onClose: () => void;
+  onCreate?: () => void;
+};
+
+export default function MonsterCreationModal({
+  onClose,
+  onCreate,
+}: MonsterCreationModalProps) {
+  const router = useRouter();
+
+  const handleCreation = () => {
+    router.push('/monster/new');
+    onCreate?.();
+  };
+
+  return (
+    <Modal open>
+      <Modal.Dimmed />
+      <Modal.Content>
+        <Modal.Title>새로운 퇴사몬을 만들까요?</Modal.Title>
+        <Modal.Description>
+          완료된 퇴사몬은
+          <br />
+          설정의 퇴사몬 보관함으로 이동해요
+        </Modal.Description>
+        <div className="flex gap-8">
+          <Modal.Button variant="secondary" onClick={onClose} aria-label="닫기">
+            닫기
+          </Modal.Button>
+          <Modal.Button
+            variant="primary"
+            onClick={handleCreation}
+            aria-label="만들기"
+          >
+            만들기
+          </Modal.Button>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #83 
- 관련 Figma : [퇴사몬 생성 팝업](https://www.figma.com/design/KngSOT6E1hJI5tEnUVTnvf/%5B%EB%94%94%EC%9E%90%EC%9D%B8%5D-%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9D%BC%ED%94%BC_0420ver?node-id=1629-9868&t=iNSVKuKz1Dkrrwl2-4)

### ⚙️ Changes

- 새로운 몬스터 만들기 모달 컴포넌트 구현
- RefMonsterFlipCard 컴포넌트 내부 새로운 몬스터 만들기 버튼 추가

### 📸 스크린샷 (선택)
<img width="240" alt="image" src="https://github.com/user-attachments/assets/05cfeff3-d730-4c30-a161-a8f2ad91354a">
<img width="240" alt="image" src="https://github.com/user-attachments/assets/b9e552fd-db77-450d-bb99-9dc4a1286694">