### PR TITLE
몬스터 생성 페이지 관련 수정 사항 & 로그인/로그아웃 수정

### DIFF
--- a/src/app/(route)/(auth)/signin/components/kakao-login-btn.tsx
+++ b/src/app/(route)/(auth)/signin/components/kakao-login-btn.tsx
@@ -6,20 +6,22 @@ import Button from '@components/common/Button';
 
 import cn from '@utils/cn';
 
-import signIn from '../utils/signIn';
+import useSignIn from '../hooks/useSignin';
 
 type Props = {
   className?: string;
 };
 
 function KakaoLoginBtn({ className }: Props) {
-  const handleLogin = () => signIn('kakao');
+  const { mutate: signIn, isPending } = useSignIn('kakao');
+
+  const handleLogin = () => signIn();
 
   return (
-    /** kakao_login_medium_wide */
     <Button
       size="small"
       type="button"
+      loading={isPending}
       onClick={handleLogin}
       className={cn(
         'flex h-[45px] w-full items-center bg-[#FEE500] px-[14px]',

--- a/src/app/(route)/(auth)/signin/hooks/useSignin.ts
+++ b/src/app/(route)/(auth)/signin/hooks/useSignin.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+
+import requestSignIn from '@api/auth/base/signin';
+
+import { Providers } from '@type/auth';
+
+import type { AxiosError } from 'axios';
+
+const useSignIn = (provider: Providers) => {
+  return useMutation({
+    mutationKey: ['auth', 'signin'],
+    mutationFn: () => requestSignIn({ provider }),
+    onSuccess: ({ data: { url } }) => {
+      window.location.href = url;
+    },
+    onError: (error: AxiosError<{ errorMessage: string }>) => {
+      const errorMessage =
+        error.response?.data.errorMessage || '잠시 후 다시 시도해주세요';
+
+      //  TODO. toast 로 변경하기
+      console.log(errorMessage);
+    },
+  });
+};
+
+export default useSignIn;

--- a/src/app/(route)/(auth)/signin/hooks/useSignout.ts
+++ b/src/app/(route)/(auth)/signin/hooks/useSignout.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+
+import requestSignOut from '@api/auth/base/signout';
+
+type Props = {
+  redirect?: boolean;
+  callbackUrl?: string;
+};
+
+const useSignout = ({ redirect, callbackUrl }: Props) => {
+  return useMutation({
+    mutationKey: ['auth', 'signout'],
+    mutationFn: requestSignOut,
+    onSuccess: () => {
+      if (callbackUrl) {
+        const nextUrl = callbackUrl.startsWith('http')
+          ? callbackUrl
+          : `${process.env.NEXT_PUBLIC_DOMAIN_NAME}${callbackUrl}`;
+
+        window.location.href = nextUrl;
+        return;
+      }
+
+      if (redirect) {
+        window.location.reload();
+      }
+    },
+  });
+};
+
+export default useSignout;

--- a/src/app/(route)/(monster)/component/MainHeader/Setting/index.tsx
+++ b/src/app/(route)/(monster)/component/MainHeader/Setting/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEventHandler, ReactElement, useReducer } from 'react';
+import { MouseEventHandler, ReactElement } from 'react';
 
 import Drawer from '@components/common/navigation/Drawer';
 import Menu from '@components/common/navigation/Menu';
@@ -9,30 +9,17 @@ import SignoutConfirmModal from '@components/modals/SignoutConfirmModal';
 
 import useModal from '@hooks/useModal';
 
+import useSignout from 'src/app/(route)/(auth)/signin/hooks/useSignout';
 import EditContent from 'src/app/(route)/profile/edit/components/EditForm';
 
 import MonsterList from './drawer-contents/MonsterList';
-
-type LoadingType = 'signout';
-type LoadingState = Record<LoadingType, boolean>;
-type LoadingReducer = (
-  state: LoadingState,
-  payload: LoadingState,
-) => LoadingState;
 
 type SettingProps = {
   close: () => void;
 };
 
 export default function Setting({ close }: SettingProps) {
-  const [{ signout }, updater] = useReducer<LoadingReducer>(
-    (state, payload) => {
-      return { ...state, ...payload };
-    },
-    {
-      signout: false,
-    },
-  );
+  const { mutate: signOut, isPending } = useSignout({ callbackUrl: '/signin' });
 
   const { openModal, closeModal } = useModal(() => null);
 
@@ -69,9 +56,8 @@ export default function Setting({ close }: SettingProps) {
         onCancel={closeModal}
         onSignout={() => {
           closeModal();
-          updater({ signout: true });
+          signOut();
         }}
-        onSignoutFailed={() => updater({ signout: true })}
       />
     ));
   };
@@ -112,7 +98,7 @@ export default function Setting({ close }: SettingProps) {
         <Menu.Item
           type="button"
           component="button"
-          loading={signout}
+          loading={isPending}
           onClick={handleSignout}
           aria-label="로그아웃"
         >

--- a/src/app/(route)/(monster)/monster/produce/page.tsx
+++ b/src/app/(route)/(monster)/monster/produce/page.tsx
@@ -34,7 +34,11 @@ function MonsterProducePage() {
       <Funnel>
         {/* 감정 설정 */}
         <Funnel.Step name="emotion">
-          <MonsterLayout title={title.emotion} goNext={() => setStep('stress')}>
+          <MonsterLayout
+            title={title.emotion}
+            control={['다음으로']}
+            goNext={() => setStep('stress')}
+          >
             <SelectEmotion />
           </MonsterLayout>
         </Funnel.Step>

--- a/src/app/(route)/(monster)/page.tsx
+++ b/src/app/(route)/(monster)/page.tsx
@@ -19,8 +19,8 @@ async function Home() {
 
   return (
     <section>
+      <MainHeader />
       <HydrateWithAuth queries={messageQueries}>
-        <MainHeader />
         <div className="flex h-[calc(100vh-48px)] w-screen px-32">
           {/* [TODO] ErrorBoundary 개선 */}
           <ErrorBoundary fallback={<>error</>}>

--- a/src/app/components/modals/MonsterCreationModal.tsx
+++ b/src/app/components/modals/MonsterCreationModal.tsx
@@ -16,8 +16,9 @@ export default function MonsterCreationModal({
   const router = useRouter();
 
   const handleCreation = () => {
-    router.push('/monster/new');
+    router.push('/monster/produce');
     onCreate?.();
+    onClose();
   };
 
   return (

--- a/src/app/components/modals/SignoutConfirmModal.tsx
+++ b/src/app/components/modals/SignoutConfirmModal.tsx
@@ -1,25 +1,16 @@
 // import toast from 'react-hot-toast';
-import { Modal } from '@components/common/Modal';
 
-import signOut from 'src/app/(route)/(auth)/signin/utils/signout';
+import { Modal } from '@components/common/Modal';
 
 type SignoutConfirmModalProps = {
   onCancel: () => void;
   onSignout?: () => void;
-  onSignoutFailed?: () => void;
 };
 
 export default function SignoutConfirmModal({
   onCancel,
   onSignout,
-  onSignoutFailed,
 }: SignoutConfirmModalProps) {
-  const handleSignout = () => {
-    signOut({ callbackUrl: '/signin' })
-      .then(() => onSignout?.())
-      .catch(() => onSignoutFailed?.());
-  };
-
   return (
     <Modal open>
       <Modal.Dimmed />
@@ -36,7 +27,7 @@ export default function SignoutConfirmModal({
             취소
           </Modal.Button>
           <Modal.Button
-            onClick={handleSignout}
+            onClick={onSignout}
             aria-label="로그아웃"
             className="bg-red-60"
           >

--- a/src/app/middlewares/factory/withMonsterHandler.ts
+++ b/src/app/middlewares/factory/withMonsterHandler.ts
@@ -1,9 +1,13 @@
 import { NextMiddleware, NextResponse } from 'next/server';
 
 import { API_URLS } from '@api/api.constants';
+import { GetMonsterRefResponse } from '@api/monster/types';
 
-import { decrypt } from 'src/app/(route)/api/auth/[...auth]/utils/crypto';
+import { setCookie } from 'src/app/(route)/api/auth/[...auth]/utils/cookie';
+import { encrypt } from 'src/app/(route)/api/auth/[...auth]/utils/crypto';
 import tokenPrefix from 'src/app/(route)/api/auth/[...auth]/utils/token-prefix';
+
+import refreshUserToken from '../utils/refresh-token';
 
 function withMonsterHandler(middleware: NextMiddleware): NextMiddleware {
   return async (request, event) => {
@@ -15,21 +19,49 @@ function withMonsterHandler(middleware: NextMiddleware): NextMiddleware {
     }
 
     try {
-      const accessToken = request.cookies.get(tokenPrefix('accessToken'));
-      const data = await fetch(
-        `${process.env.NEXT_PUBLIC_API_DOMAIN_NAME}${API_URLS.MONSTER.GET_REF_MONSTER}`,
-        {
-          headers: {
-            ...(accessToken && {
-              Authorization: `Bearer ${decrypt(accessToken.value, process.env.AUTH_SECRET)}`,
-            }),
-          },
-        },
-      ).then((res) => res.json());
+      const secret = process.env.AUTH_SECRET;
+      const { accessToken, refreshToken } = await refreshUserToken(
+        request,
+        secret,
+      );
 
-      return data
-        ? NextResponse.redirect(`${process.env.NEXT_PUBLIC_DOMAIN_NAME}/`)
-        : await middleware(request, event);
+      const headers = {
+        ...(accessToken && {
+          Authorization: `Bearer ${accessToken}`,
+        }),
+      };
+
+      const data = (await fetch(
+        `${process.env.NEXT_PUBLIC_API_DOMAIN_NAME}/api/v1${API_URLS.MONSTER.GET_REF_MONSTER}`,
+        { headers },
+      ).then((res) => res.json())) as
+        | GetMonsterRefResponse
+        | { code: string; message: string };
+
+      if ('code' in data) {
+        throw new Error(data.code);
+      }
+
+      const response =
+        data.currentInteractionCount !== data.interactionCount
+          ? NextResponse.redirect(`${process.env.NEXT_PUBLIC_DOMAIN_NAME}/`)
+          : NextResponse.next();
+
+      return setCookie(
+        [
+          {
+            key: tokenPrefix('accessToken'),
+            value: encrypt(accessToken, secret),
+            proteced: true,
+          },
+          {
+            key: tokenPrefix('refreshToken'),
+            value: encrypt(refreshToken, secret),
+            proteced: true,
+          },
+        ],
+        response,
+      );
     } catch (error) {
       return NextResponse.redirect(`${process.env.NEXT_PUBLIC_DOMAIN_NAME}/`);
     }

--- a/src/app/middlewares/factory/withSignUpHandle.ts
+++ b/src/app/middlewares/factory/withSignUpHandle.ts
@@ -5,51 +5,14 @@ import {
   NextResponse,
 } from 'next/server';
 
-import { TokenResponse } from '@api/schema/token';
-
 import {
   deleteCookie,
-  getCookie,
   setCookie,
 } from 'src/app/(route)/api/auth/[...auth]/utils/cookie';
-import {
-  decrypt,
-  encrypt,
-} from 'src/app/(route)/api/auth/[...auth]/utils/crypto';
+import { encrypt } from 'src/app/(route)/api/auth/[...auth]/utils/crypto';
 import tokenPrefix from 'src/app/(route)/api/auth/[...auth]/utils/token-prefix';
 
-const refreshUserToken = async (request: NextRequest, secret: string) => {
-  const {
-    [tokenPrefix('accessToken')]: access,
-    [tokenPrefix('refreshToken')]: refresh,
-  } = getCookie(
-    [tokenPrefix('accessToken'), tokenPrefix('refreshToken')],
-    request,
-  );
-
-  if (!access || !refresh) {
-    throw new Error('토큰이 없습니다.');
-  }
-
-  const oldAccessToken = decrypt(access, secret);
-  const oldRefreshToken = decrypt(refresh, secret);
-
-  const { accessToken, refreshToken, code, username } = await fetch(
-    `${process.env.NEXT_PUBLIC_API_DOMAIN_NAME}/api/v1/members/token/refresh`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${oldAccessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        refreshToken: oldRefreshToken,
-      }),
-    },
-  ).then((res) => res.json() as Promise<TokenResponse>);
-
-  return { accessToken, refreshToken, code, username };
-};
+import refreshUserToken from '../utils/refresh-token';
 
 function withSignUpHandle(middleware: NextMiddleware) {
   return async (request: NextRequest, event: NextFetchEvent) => {

--- a/src/app/middlewares/factory/withSignUpHandle.ts
+++ b/src/app/middlewares/factory/withSignUpHandle.ts
@@ -65,15 +65,14 @@ function withSignUpHandle(middleware: NextMiddleware) {
         await refreshUserToken(request, secret);
 
       if (!accessToken) {
-        throw new Error('No AccessTOken');
+        throw new Error('No AccessToken');
       }
 
       const redirect = request.nextUrl.clone();
-      // redirect.pathname = code === 102 ? '/' : redirect.pathname;
+      redirect.pathname = code === 102 ? '/' : redirect.pathname;
       redirect.search =
         (code === 100 && `code=${code}`) ||
         (code === 101 && `code=${code}&user=${username}`) ||
-        (code === 102 && `code=${code}&user=${username}`) ||
         '';
 
       const response =

--- a/src/app/middlewares/utils/refresh-token.ts
+++ b/src/app/middlewares/utils/refresh-token.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+
+import { TokenResponse } from '@api/schema/token';
+
+import { getCookie } from 'src/app/(route)/api/auth/[...auth]/utils/cookie';
+import { decrypt } from 'src/app/(route)/api/auth/[...auth]/utils/crypto';
+import tokenPrefix from 'src/app/(route)/api/auth/[...auth]/utils/token-prefix';
+
+const refreshUserToken = async (request: NextRequest, secret: string) => {
+  const {
+    [tokenPrefix('accessToken')]: access,
+    [tokenPrefix('refreshToken')]: refresh,
+  } = getCookie(
+    [tokenPrefix('accessToken'), tokenPrefix('refreshToken')],
+    request,
+  );
+
+  if (!access || !refresh) {
+    throw new Error('토큰이 없습니다.');
+  }
+
+  const oldAccessToken = decrypt(access, secret);
+  const oldRefreshToken = decrypt(refresh, secret);
+
+  const { accessToken, refreshToken, code, username } = await fetch(
+    `${process.env.NEXT_PUBLIC_API_DOMAIN_NAME}/api/v1/members/token/refresh`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${oldAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        refreshToken: oldRefreshToken,
+      }),
+    },
+  ).then((res) => res.json() as Promise<TokenResponse>);
+
+  return { accessToken, refreshToken, code, username };
+};
+
+export default refreshUserToken;

--- a/src/app/providers/HydrationAuthBoudary.tsx
+++ b/src/app/providers/HydrationAuthBoudary.tsx
@@ -15,11 +15,14 @@ async function HydrateWithAuth(props: Props) {
     {},
   );
 
-  const {
-    data: { accessToken },
-  } = await getServerSession(header);
-
-  setAuthHeader(accessToken);
+  await Promise.race([
+    new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    }),
+    getServerSession(header).then(({ data: { accessToken } }) => {
+      setAuthHeader(accessToken);
+    }),
+  ]);
 
   return <Hydrate {...props} />;
 }


### PR DESCRIPTION
### ⚙️ Changes

몬스터 만들러 가기 버튼 url 수정하였습니다. 
- 홈에서 새로운 몬스터 만들기 버튼 내 router push 경로 수정

미들웨어 로직을 수정하였습니다. 
- 기존 회원이 다시 회원가입 페이지로 이동 못하도록 방어 
- 아직 활성화된 몬스터가 있는 경우 새로운 몬스터 페이지로 이동 못하도록 방어
- 현재 몬스터가 받은 counter 와 총 받을 수 있는 counter 가 동일한 경우, 새로운 몬스터 생성 가능하도록 설정

로그인/로그아웃 훅 생성
- mutation 훅 pending 여부에 따라 로그인/로그아웃 버튼 로딩 UI 처리

