### PR TITLE
Bugfix/QA

### DIFF
--- a/src/app/(route)/(monster)/component/MainHeader/Setting/index.tsx
+++ b/src/app/(route)/(monster)/component/MainHeader/Setting/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEventHandler, ReactElement } from 'react';
+import { MouseEventHandler, ReactElement, useState } from 'react';
 
 import Drawer from '@components/common/navigation/Drawer';
 import Menu from '@components/common/navigation/Menu';
@@ -15,33 +15,25 @@ import EditContent from 'src/app/(route)/profile/edit/components/EditForm';
 import MonsterList from './drawer-contents/MonsterList';
 
 type SettingProps = {
+  open?: boolean;
   close: () => void;
 };
 
-export default function Setting({ close }: SettingProps) {
+export default function Setting({ open = false, close }: SettingProps) {
   const { mutate: signOut, isPending } = useSignout({ callbackUrl: '/signin' });
+
+  const [subOpen, setSubOpen] = useState(false);
+  const [subContent, setSubContent] = useState<ReactElement>();
+  const [subContentLabel, setsubContentLabel] = useState('');
 
   const { openModal, closeModal } = useModal(() => null);
 
   const openByDrawer = (target: Element, content: ReactElement) => {
-    const ariaLabel = target.getAttribute('aria-label');
+    const label = target.getAttribute('data-label');
 
-    return openModal(() => (
-      <Drawer open>
-        <Header className="grid grid-cols-6 gap-4">
-          <Header.IconButton
-            name="arrow-back"
-            aria-label="뒤로가기"
-            className="col-span-1 col-start-1"
-            onClick={closeModal}
-          />
-          <Header.Title className="col-span-4 col-start-2 mx-auto">
-            {ariaLabel}
-          </Header.Title>
-        </Header>
-        {content}
-      </Drawer>
-    ));
+    setSubOpen(true);
+    setSubContent(content);
+    setsubContentLabel(label!);
   };
 
   const handleViewCollection: MouseEventHandler = (e) =>
@@ -68,7 +60,7 @@ export default function Setting({ close }: SettingProps) {
   };
 
   return (
-    <Drawer open>
+    <Drawer open={open} className="">
       <Header className="grid grid-cols-6 gap-4">
         <Header.IconButton
           name="arrow-back"
@@ -88,6 +80,7 @@ export default function Setting({ close }: SettingProps) {
             component="button"
             onClick={handleViewCollection}
             aria-label="퇴사몬 보관함"
+            data-label="퇴사몬 보관함"
           >
             퇴사몬 보관함
           </Menu.Item>
@@ -99,6 +92,7 @@ export default function Setting({ close }: SettingProps) {
             component="button"
             onClick={handleEditProfile}
             aria-label="프로필 수정"
+            data-label="프로필 수정"
           >
             프로필 수정
           </Menu.Item>
@@ -108,17 +102,34 @@ export default function Setting({ close }: SettingProps) {
             loading={isPending}
             onClick={handleSignout}
             aria-label="로그아웃"
+            data-label="로그아웃"
           >
             로그아웃
           </Menu.Item>
         </Menu>
 
         <Menu>
-          <Menu.Item component="a" href="/">
+          <Menu.Item component="a" href="/" data-label="제작정보">
             제작정보
           </Menu.Item>
         </Menu>
       </div>
+
+      {/* SubDrawer */}
+      <Drawer open={subOpen}>
+        <Header className="grid grid-cols-6 gap-4">
+          <Header.IconButton
+            name="arrow-back"
+            aria-label="뒤로가기"
+            className="col-span-1 col-start-1"
+            onClick={() => setSubOpen(false)}
+          />
+          <Header.Title className="col-span-4 col-start-2 mx-auto">
+            {subContentLabel}
+          </Header.Title>
+        </Header>
+        {subContent}
+      </Drawer>
     </Drawer>
   );
 }

--- a/src/app/(route)/(monster)/component/MainHeader/index.tsx
+++ b/src/app/(route)/(monster)/component/MainHeader/index.tsx
@@ -1,24 +1,31 @@
 'use client';
 
-import Header from '@components/Header';
+import { useState } from 'react';
 
-import useModal from '@hooks/useModal';
+import Header from '@components/Header';
 
 import Setting from './Setting';
 
 export default function MainHeader() {
-  const { openModal, closeModal } = useModal(() => (
-    <Setting close={closeModal} />
-  ));
+  const [open, setOpen] = useState(false);
+
+  const toggleDrawer = (newOpen: boolean) => () => setOpen(newOpen);
 
   return (
-    <Header className="grid grid-cols-6 gap-4">
-      <Header.LinkLogo size={24} href="/" className="col-span-4 col-start-2" />
-      <Header.IconButton
-        className="col-span-1 ml-auto"
-        name="hamburger"
-        onClick={() => openModal()}
-      />
-    </Header>
+    <>
+      <Header className="grid grid-cols-6 gap-4">
+        <Header.LinkLogo
+          size={24}
+          href="/"
+          className="col-span-4 col-start-2"
+        />
+        <Header.IconButton
+          className="col-span-1 ml-auto"
+          name="hamburger"
+          onClick={toggleDrawer(true)}
+        />
+      </Header>
+      <Setting open={open} close={toggleDrawer(false)} />
+    </>
   );
 }

--- a/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/HelperToast.tsx
+++ b/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/HelperToast.tsx
@@ -1,0 +1,50 @@
+import { useRef } from 'react';
+import toast, { Toaster, resolveValue } from 'react-hot-toast';
+
+import BaseText from '@components/common/Text/BaseText';
+
+import useOutsideClick from '@hooks/useOutsideClick';
+
+import cn from '@utils/cn';
+
+export default function HelperToast() {
+  const ref = useRef(null);
+
+  useOutsideClick(ref, () => toast.dismiss(), 'mousedown');
+
+  return (
+    <Toaster
+      containerStyle={{
+        position: 'absolute',
+      }}
+      position="bottom-center"
+      toastOptions={{
+        duration: 999999, // 인터랙션 시작 시, dismiss 처리
+        ariaProps: {
+          role: 'status',
+          'aria-live': 'polite',
+        },
+      }}
+    >
+      {(t) => (
+        <div
+          ref={ref}
+          role="none"
+          className={cn(
+            t.visible ? 'animate-enter' : 'animate-leave',
+            'flex h-max w-max items-center justify-center rounded-circular bg-[#171719bd] px-[16px] py-[9px]',
+          )}
+        >
+          <BaseText
+            component="span"
+            variant="label-2"
+            weight="medium"
+            color="normal"
+          >
+            {resolveValue(t.message, t)}
+          </BaseText>
+        </div>
+      )}
+    </Toaster>
+  );
+}

--- a/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/Skeleton.tsx
+++ b/src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/Skeleton.tsx
@@ -4,14 +4,14 @@ import OutlineCard from '@components/cards/OutlineCard';
 
 import tokens from 'tokens/color/base.json';
 
-const CARD_WIDTH = 312;
-const CARD_HEIGHT = 400;
+const SUB_FLIP_CARD_WIDTH = 302;
+const SUB_FLIP_CARD_HEIGHT = 450;
 
 export default function SharedMonsterFlipCardSkeleton() {
   return (
     <OutlineCard
-      width={CARD_WIDTH}
-      height={CARD_HEIGHT}
+      width={SUB_FLIP_CARD_WIDTH}
+      height={SUB_FLIP_CARD_HEIGHT}
       color={tokens.color.base['cool-neutral'][22].value}
       className="flex h-full w-full flex-col justify-between overflow-visible rounded-[40px]"
     >

--- a/src/app/(route)/(monster)/monster/[slug]/share/components/ExpiredModal.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/components/ExpiredModal.tsx
@@ -1,10 +1,14 @@
+import { useRouter } from 'next/navigation';
+
 import Modal from '@components/common/feedback/Modal';
 
 type ExpiredModalProps = {
-  closeModal: () => void;
+  closeModal?: () => void;
 };
 
 export default function ExpiredModal({ closeModal }: ExpiredModalProps) {
+  const { replace } = useRouter();
+
   return (
     <Modal open>
       <Modal.Dimmed />
@@ -15,9 +19,12 @@ export default function ExpiredModal({ closeModal }: ExpiredModalProps) {
         <Modal.Button
           className="w-full"
           variant="secondary"
-          onClick={closeModal}
+          onClick={() => {
+            replace('/');
+            closeModal?.();
+          }}
         >
-          닫기
+          메인으로 이동
         </Modal.Button>
       </Modal.Content>
     </Modal>

--- a/src/app/(route)/(monster)/monster/[slug]/share/components/InteractionStep.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/components/InteractionStep.tsx
@@ -8,9 +8,8 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import Button from '@components/common/Button';
 import Header from '@components/Header';
 
-import SharedMonsterFlipCard from 'src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard';
-import SharedMonsterFlipCardSkeleton from 'src/app/(route)/(monster)/component/cards/SharedMonsterFlipCard/Skeleton';
-
+import SharedMonsterFlipCard from '../../../../component/cards/SharedMonsterFlipCard';
+import SharedMonsterFlipCardSkeleton from '../../../../component/cards/SharedMonsterFlipCard/Skeleton';
 import { useGuestContext, useGuestUpdate } from '../context/guest.context';
 import Error from '../error';
 
@@ -35,8 +34,8 @@ export default function InteractionStep({
       </Header>
       <QueryErrorResetBoundary>
         {({ reset }) => (
-          <ErrorBoundary FallbackComponent={Error} onReset={reset}>
-            <Suspense fallback={<SharedMonsterFlipCardSkeleton />}>
+          <Suspense fallback={<SharedMonsterFlipCardSkeleton />}>
+            <ErrorBoundary FallbackComponent={Error} onReset={reset}>
               <SharedMonsterFlipCard
                 clear={clear}
                 monsterId={slug}
@@ -45,8 +44,8 @@ export default function InteractionStep({
                   onCompeleteInteraction?.();
                 }}
               />
-            </Suspense>
-          </ErrorBoundary>
+            </ErrorBoundary>
+          </Suspense>
         )}
       </QueryErrorResetBoundary>
       <nav className="flex w-full p-[20px]">

--- a/src/app/(route)/(monster)/monster/[slug]/share/error.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/error.tsx
@@ -4,38 +4,22 @@
 import { useEffect } from 'react';
 import { FallbackProps } from 'react-error-boundary';
 
-import OutlineCard from '@components/cards/OutlineCard';
 import Button from '@components/common/Button';
 import BaseText from '@components/common/Text/BaseText';
+
+import ExpiredModal from './components/ExpiredModal';
 
 export default function Error({ error, resetErrorBoundary }: FallbackProps) {
   const status = Number(error.response?.status);
 
   useEffect(() => {
     // Log the error to an error reporting service
-    console.error(error);
+    if (status !== 404) console.error(error);
   }, [error]);
 
-  if (status === 404)
-    // [TODO] 404 컴포넌트 분리
-    return (
-      <div>
-        <OutlineCard
-          width={312}
-          height={460}
-          className="flex h-full w-full flex-col justify-center overflow-visible rounded-[40px] text-cool-neutral-22"
-        >
-          <BaseText
-            variant="body-1"
-            weight="semibold"
-            component="h2"
-            color="strong"
-          >
-            {error.response?.data.message}
-          </BaseText>
-        </OutlineCard>
-      </div>
-    );
+  if (status === 404) {
+    return <ExpiredModal />;
+  }
 
   return (
     <div>

--- a/src/app/(route)/(monster)/monster/[slug]/share/page.tsx
+++ b/src/app/(route)/(monster)/monster/[slug]/share/page.tsx
@@ -71,7 +71,7 @@ export default function SharePage({ params: { slug } }: SharePagesProps) {
           <Funnel.Step name="encouragement">
             <EncouragementStep
               goPrev={() => {
-                setStep('done');
+                setStep('interactions');
               }}
               goNext={(data) => {
                 send(data);

--- a/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
@@ -10,7 +10,7 @@ import Tooltip from '@components/common/Tooltip';
 
 import cn from '@utils/cn';
 
-import { EMOTION } from '@api/schema/monster';
+import { EMOTION, DECORATION_TYPE } from '@api/schema/monster';
 
 import type { UserInfo } from '../../../../(auth)/signup/context/context.type';
 
@@ -76,6 +76,7 @@ function SelectEmotion() {
   const { setBtnDisabled } = useMonsterLayout();
   const {
     control,
+    setValue,
     formState: { errors },
   } = useFormContext<UserInfo>();
 

--- a/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
@@ -29,6 +29,17 @@ const EMOTIONS = [
   },
 ];
 
+const DEFAULT_BG = {
+  [EMOTION.ANGER]: {
+    decorationType: DECORATION_TYPE.BACKGROUND_COLOR,
+    decorationValue: '#F450A6',
+  },
+  [EMOTION.DEPRESSION]: {
+    decorationType: DECORATION_TYPE.BACKGROUND_COLOR,
+    decorationValue: '#4485FD',
+  },
+};
+
 const gridStyles = cva('grid', {
   variants: {
     row: {
@@ -73,6 +84,11 @@ function SelectEmotion() {
   useEffect(() => {
     setBtnDisabled(!!errors.emotion || selectedId === '');
   }, [selectedId, errors]);
+
+  // 감정별 기본 배경 색상 지정
+  useEffect(() => {
+    if (selectedId) setValue('decorations', [DEFAULT_BG[selectedId]]);
+  }, [selectedId]);
 
   return (
     <fieldset className="flex h-[calc(100%+95px)] w-full flex-col">

--- a/src/app/components/common/Tooltip/TooltipLabel.tsx
+++ b/src/app/components/common/Tooltip/TooltipLabel.tsx
@@ -43,7 +43,7 @@ const TooltipLabel = forwardRef<HTMLButtonElement, Props>(
           {...restProps}
         >
           {label}
-          <Icon name={icons} ref={ref} />
+          <Icon name={icons} ref={ref} size={20} />
         </FormHelperText>
       </button>
     );

--- a/src/app/components/common/data-display/Icon/index.tsx
+++ b/src/app/components/common/data-display/Icon/index.tsx
@@ -29,24 +29,19 @@ export const IconMap = {
 } as const;
 
 export const iconStyles = cva(
-  [
-    'inline-flex',
-    'items-center',
-    'justify-center',
-    '[&>svg]:w-max [&>svg]:h-max',
-  ],
+  ['inline-flex', 'items-center', 'justify-center'],
   {
     variants: {
       size: {
-        12: ['w-12', 'h-12'],
-        16: ['w-16', 'h-16'],
-        20: ['w-20', 'h-20'],
-        24: ['w-24', 'h-24'],
-        32: ['w-32', 'h-32'],
-        40: ['w-40', 'h-40'],
-        44: ['w-44', 'h-44'],
-        48: ['w-48', 'h-48'],
-        64: ['w-64', 'h-64'],
+        12: ['w-12', 'h-12', '[&>svg]:w-12'],
+        16: ['w-16', 'h-16', '[&>svg]:w-16'],
+        20: ['w-20', 'h-20', '[&>svg]:w-20'],
+        24: ['w-24', 'h-24', '[&>svg]:w-24'],
+        32: ['w-32', 'h-32', '[&>svg]:w-32'],
+        40: ['w-40', 'h-40', '[&>svg]:w-40'],
+        44: ['w-44', 'h-44', '[&>svg]:w-44'],
+        48: ['w-48', 'h-48', '[&>svg]:w-48'],
+        64: ['w-64', 'h-64', '[&>svg]:w-64'],
       },
       stroke: {
         inherit: 'text-inherit',

--- a/src/app/components/common/data-display/Icon/index.tsx
+++ b/src/app/components/common/data-display/Icon/index.tsx
@@ -29,7 +29,12 @@ export const IconMap = {
 } as const;
 
 export const iconStyles = cva(
-  ['inline-flex', 'items-center', 'justify-center'],
+  [
+    'inline-flex',
+    'items-center',
+    'justify-center',
+    '[&>svg]:w-max [&>svg]:h-max',
+  ],
   {
     variants: {
       size: {

--- a/src/app/components/common/navigation/Drawer/index.tsx
+++ b/src/app/components/common/navigation/Drawer/index.tsx
@@ -1,5 +1,4 @@
 import { ComponentProps, useId } from 'react';
-import { createPortal } from 'react-dom';
 
 import { AnimatePresence, LazyMotion, domAnimation, m } from 'framer-motion';
 
@@ -17,7 +16,7 @@ export default function Drawer({
 }: DrawerProps) {
   const uid = useId();
 
-  return createPortal(
+  return (
     <LazyMotion features={domAnimation}>
       {open && (
         <AnimatePresence mode="wait" onExitComplete={() => null}>
@@ -32,7 +31,7 @@ export default function Drawer({
               animate: {
                 opacity: 1,
                 transition: {
-                  duration: 0.3,
+                  duration: 0.2,
                 },
               },
               exit: {
@@ -50,18 +49,20 @@ export default function Drawer({
               animate={{
                 left: 0,
               }}
-              className={cn('fixed right-0 top-0 w-full bg-cool-neutral-5', {
-                'full-height': !isIOS,
-                'full-height-ios': isIOS,
-                className,
-              })}
+              className={cn(
+                'absolute right-0 top-0 z-[10] w-full bg-cool-neutral-5',
+                {
+                  'full-height': !isIOS,
+                  'full-height-ios': isIOS,
+                  className,
+                },
+              )}
             >
               {children}
             </m.aside>
           </m.div>
         </AnimatePresence>
       )}
-    </LazyMotion>,
-    document.body,
+    </LazyMotion>
   );
 }

--- a/src/app/constant/confetti.ts
+++ b/src/app/constant/confetti.ts
@@ -1,0 +1,24 @@
+const ConfettiMap = {
+  mad: {
+    image: {
+      src: '/images/thunder0000.png',
+      width: 50,
+      height: 50,
+    },
+    start: 'center',
+    speed: 7,
+    particleNumber: 6,
+  },
+  sad: {
+    image: {
+      src: '/images/heart_active.webp',
+      width: 50,
+      height: 50,
+    },
+    start: 'center',
+    speed: 6,
+    particleNumber: 10,
+  },
+} as const;
+
+export default ConfettiMap;

--- a/src/app/hooks/useOutsideClick.ts
+++ b/src/app/hooks/useOutsideClick.ts
@@ -34,5 +34,6 @@ export default function useOutsideClick<T extends HTMLElement = HTMLElement>(
     return () => {
       window.removeEventListener(eventType, listener, options);
     };
-  }, [ref, eventType, options, handler]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref]);
 }

--- a/src/app/layout/BaseLayout.tsx
+++ b/src/app/layout/BaseLayout.tsx
@@ -4,6 +4,8 @@ type BaseLayoutProps = PropsWithChildren;
 
 export default function BaseLayout({ children }: BaseLayoutProps) {
   return (
-    <main className="mx-auto h-dvh max-w-md grow touch-auto">{children}</main>
+    <main className="relative mx-auto h-dvh max-w-md grow touch-auto overflow-hidden">
+      {children}
+    </main>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,6 +36,32 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      keyframes: {
+        'fade-in-up': {
+          '0%': {
+            opacity: '0',
+            transform: 'translate3d(0, 100%, 0)',
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'translate3d(0, 0, 0)',
+          },
+        },
+        'fade-in-down': {
+          '0%': {
+            opacity: '1',
+            transform: 'translate3d(0, 0%, 0)',
+          },
+          '100%': {
+            opacity: '0',
+            transform: 'translate3d(0, 100, 0)',
+          },
+        },
+      },
+      animation: {
+        enter: 'fade-in-up 300ms ease-in-out 1',
+        leave: 'fade-in-down 300ms ease-in forwards',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 :
- 관련 Figma : 

### ⚙️ Changes

- useOutsideClick `useEffect` 의존성 배열 수정
  addEventListener `once` 옵션 적용 시, 오류가 발생하는 것을 확인하여 `useEffect` 의존성 배열 수정하였습니다. 
- 몬스터 생성 / 감정 선택 시, 백그라운드 기본 색상 설정
- Drawer 레이아웃 내부에서 렌더링 되도록 수정
  - 기존 createPortal을 통해 부모 컴포넌트와 독립적으로 렌더링하던 로직을 요구사항에 맞춰 부모 컴포넌트 레이아웃 내부에서 그려지도록 수정하였습니다. 
  - 이후 createPortal을 통해 최상단에 렌더링할 경우에는 이전과 동일하게 useModal 훅을 사용해주시면 될 것 같습니다. 
  
- `tailwind.config.ts` fade-in-up/down 애니메이션 추가
  - 공유 카드 내부 토스트 사용 시, `framer-motion` 대신 CSS 애니메이션으로 fade-in/out을 처리하기 위해 추가하였습니다.

### 📸 스크린샷 (선택)

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/60415ea3-392e-4a46-bbf9-c217d642f2a8">