### PR TITLE
메세지 에너지 적용 오류 수정

### DIFF
--- a/src/app/(route)/(monster)/component/Message/MessageConfirmModal.tsx
+++ b/src/app/(route)/(monster)/component/Message/MessageConfirmModal.tsx
@@ -32,6 +32,8 @@ function MessageConfirmModal({
   message: { content, sender, checked, messageId },
 }: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
   const queryClient = getQueryClient();
 
   const [messageRead, setMessageRead] = useState(checked);
@@ -64,13 +66,18 @@ function MessageConfirmModal({
     (data?.interactionCountPerEncouragement || 0) *
     (emotion === 'ANGER' ? -1 : 1);
 
-  const handleClick: TouchEventHandler = async () => {
+  const handleClick = async () => {
     const method = messageRead ? closeModal : confirm;
 
     method();
   };
 
-  useOutsideClick(modalRef, () => closeModal(), 'mousedown');
+  const handleTouchEnd: TouchEventHandler = async (e) => {
+    e.preventDefault();
+    handleClick();
+  };
+
+  useOutsideClick([modalRef, buttonRef], () => closeModal(), 'mousedown');
 
   return (
     <Modal open>
@@ -141,8 +148,10 @@ function MessageConfirmModal({
         </section>
 
         <Button
+          ref={buttonRef}
           size="medium"
-          onTouchEnd={handleClick}
+          onClick={handleClick}
+          onTouchEnd={handleTouchEnd}
           variant={messageRead ? 'secondary' : 'primary'}
         >
           <Text variant="body-2" weight={messageRead ? 'medium' : 'semibold'}>


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 :
- 관련 Figma : 

### ⚙️ Changes

- 모달 컨텐츠 외부 버튼 클릭 시 에너지 적용 안되는 이슈 수정
  - useOutsideClick ref[]에 버튼 ref 추가하였습니다. 
- 에너지 적용 버튼 웹 대응 이벤트 추가
  - 클릭 이벤트 추가 후, 모바일 onTouchEnd의 경우 이벤트를 전파하지 않도록 수정하였습니다. 
