### PR TITLE
🐛 fix: 몬스터 리스트 queryKey 변경

### DIFF
--- a/src/app/components/logging/ScreenView.tsx
+++ b/src/app/components/logging/ScreenView.tsx
@@ -19,9 +19,9 @@ function ScreenView({ name, children, disabled = false }: Props) {
   const { user, status } = useAuth();
 
   const { data: totalElements } = useQuery({
-    queryKey: MonsterQueryFactory.list.queryKey,
-    queryFn: () => getMonsterList({ page: 1, size: 10 }),
     enabled: status === 'authenticated',
+    queryKey: [MonsterQueryFactory.list.queryKey, 'screen-view'],
+    queryFn: () => getMonsterList({ page: 1, size: 10 }),
     select: (data) => data.data.totalElements,
   });
 
@@ -35,11 +35,8 @@ function ScreenView({ name, children, disabled = false }: Props) {
 
   useEffect(() => {
     if (disabled) return;
-    if (
-      status === 'loading' ||
-      (status === 'authenticated' && (!totalElements || !user))
-    )
-      return;
+    if (status === 'loading') return;
+    if (status === 'authenticated' && (!totalElements || !user)) return;
 
     const userProperties = {
       userId: user?.id,


### PR DESCRIPTION
### ⚙️ Changes

ScreenView 내부에서 사용 중인 monster list API 쿼리 키 변경하였습니다. 
- 몬스터 리스트 컴포넌트에서 사용 중인 쿼리키와 동일하게 세팅하여, ScreenView에서 미리 select 로 반환한 데이터가 cache 되어서 렌더링 이슈가 발생하였습니다. 
- 기존 쿼리 키에 'screen-view' 키를 추가하였습니다. 


