### PR TITLE
✨ feat: gtm loggin user property 추가

### DIFF
--- a/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
+++ b/src/app/(route)/api/auth/[...auth]/utils/redirect.ts
@@ -7,7 +7,14 @@ import { encrypt } from './crypto';
 import tokenPrefix from './token-prefix';
 
 const redirectResponse = (
-  { code, username, accessToken, refreshToken, memberId }: TokenResponse,
+  {
+    code,
+    username,
+    accessToken,
+    refreshToken,
+    memberId,
+    createdAt,
+  }: TokenResponse,
   secret: string,
 ) => {
   const destinationUrl =
@@ -34,7 +41,10 @@ const redirectResponse = (
       },
       {
         key: 'userInfo',
-        value: encrypt(JSON.stringify({ memberId, username }), secret),
+        value: encrypt(
+          JSON.stringify({ memberId, username, createdAt }),
+          secret,
+        ),
         proteced: true,
       },
     ],

--- a/src/app/api/api.constants.ts
+++ b/src/app/api/api.constants.ts
@@ -19,7 +19,7 @@ export const API_URLS = {
       REFRESH_TOKEN: `${MEMBER_BASE}/token/refresh`,
       USER_NICKNAME: `${MEMBER_BASE}/my`,
       GET_TOKEN: {
-        kakao: `${MEMBER_BASE}/login/kakao`,
+        kakao: `${MEMBER_BASE}/login/kakao/test`,
       },
     },
   },

--- a/src/app/api/schema/token.ts
+++ b/src/app/api/schema/token.ts
@@ -3,6 +3,7 @@ export interface TokenResponse {
   accessToken: string;
   refreshToken: string;
   username: string;
+  createdAt: string;
   /**
    * @description
    * 100 닉네임 설정 false & 몬스터 생성 false
@@ -21,5 +22,6 @@ export type Session = Response & {
   userInfo: {
     memberId?: number;
     username?: string;
+    createdAt?: string;
   };
 };

--- a/src/app/components/logging/ScreenView.tsx
+++ b/src/app/components/logging/ScreenView.tsx
@@ -40,6 +40,7 @@ function ScreenView({ name, children, disabled = false }: Props) {
 
     const userProperties = {
       userId: user?.id,
+      userJoinDate: user?.joinDate,
       numOfMonsters: totalElements || -1,
       lastLoginDate: ensureLoginDate(),
     };

--- a/src/app/hooks/useUserInfo.ts
+++ b/src/app/hooks/useUserInfo.ts
@@ -11,6 +11,7 @@ import { Session } from '@api/schema/token';
 type User = {
   id: number;
   name: string;
+  joinDate: string;
 };
 
 const useUserInfo = (session: Session | undefined) => {
@@ -20,15 +21,23 @@ const useUserInfo = (session: Session | undefined) => {
     if (!session || session.status === 'unauthenticated') return;
 
     const {
-      userInfo: { username, memberId },
+      userInfo: { username, memberId, createdAt },
     } = session;
 
     if (!getSessionItem('userInfo')) {
-      setSessionItem('userInfo', { name: username, id: memberId });
+      setSessionItem('userInfo', {
+        name: username,
+        id: memberId,
+        joinDate: createdAt,
+      });
     }
 
     const userInfo = getSessionItem<User>('userInfo');
-    setUser({ name: userInfo?.name || '', id: userInfo?.id || 0 });
+    setUser({
+      name: userInfo?.name || '',
+      id: userInfo?.id || 0,
+      joinDate: userInfo?.joinDate || '',
+    });
   }, [session]);
 
   useEffect(() => {


### PR DESCRIPTION
- userJoinDate 추가

### 📝 About PR 

- 관련 이슈 : #115 

### ⚙️ Changes

GTM 용 UserProperty에 userjoinDate(회워가입일) 값을 추가했습니다. 
- 최초 로그인 API 요청에 대한 응답을 userInfo 라는 이름의 쿠키에 저장합니다. 
- useAuth 훅 내부에서 session 객체를 요청하면, 해당 session 객체 내부에 userInfo 를 반환합니다. 
- 전달받은 userInfo 를 ScreenView 컴포넌트에서 gtm dataLayer 로 업데이트 합니다. 

