### PR TITLE
몬스터 생성 페이지 리팩토링 및 애니메이션 개선

### DIFF
--- a/src/app/(route)/(monster)/monster/produce/components/MosterName.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/MosterName.tsx
@@ -3,11 +3,15 @@
 import { useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
+import { LazyMotion, domAnimation, m } from 'framer-motion';
+
 import CharacterCanvas from '@components/CharacterCanvas';
 import Text from '@components/common/Text';
 import TextField from '@components/common/TextField';
 
 import stringToElement from '@utils/string-to-element';
+
+import { visible, fadeIn, hidden } from '@constant/animation';
 
 import { UserInfo } from '../../../../(auth)/signup/context/context.type';
 import useMonsterLayout from '../hooks/useMonsterLayout';
@@ -19,51 +23,70 @@ function MonsterName() {
     control,
     register,
     getValues,
-    formState: { errors },
+    formState: {
+      errors: { monsterName: monsterNameError },
+    },
   } = useFormContext<UserInfo>();
 
   const monsterName = useWatch({ control, name: 'monsterName' });
-  const story = useWatch({ control, name: 'story' });
 
   useEffect(() => {
-    setBtnDisabled(
-      !!errors.monsterName || !!errors.story || !monsterName || !story,
-    );
-  }, [monsterName, story, errors]);
+    setBtnDisabled(!!monsterNameError);
+  }, [monsterName, monsterNameError]);
 
   return (
     <>
-      <div className="flex flex-col items-center gap-8">
-        <Text
-          variant="label-2"
-          color="strong"
-          className="relative w-max rounded-[16px] bg-cool-neutral-17 px-[20px] py-[16px] text-center shadow-3"
+      <LazyMotion features={domAnimation}>
+        <m.div
+          className="flex flex-col items-center gap-8"
+          initial="hidden"
+          animate="visible"
+          exit={{ ...hidden, transition: { duration: 0.3 } }}
+          variants={{
+            visible: {
+              transition: { staggerChildren: 0.3, staggerDirection: -1 },
+            },
+          }}
         >
-          {stringToElement(['나의 감정을 담은', '퇴사몬이 등장했어요!'])}
-          <span
-            style={{
-              display: 'block',
-              position: 'absolute',
-              width: '10px',
-              height: '10px',
-              left: 0,
-              right: 0,
-              bottom: -5,
-              background: 'inherit',
-              transform: 'rotate(45deg)',
-              margin: 'auto',
+          <m.div variants={fadeIn}>
+            <Text
+              variant="label-2"
+              color="strong"
+              className="relative w-max rounded-[16px] bg-cool-neutral-17 px-[20px] py-[16px] text-center shadow-3"
+            >
+              {stringToElement(['나의 감정을 담은', '퇴사몬이 등장했어요!'])}
+              <span
+                style={{
+                  display: 'block',
+                  position: 'absolute',
+                  width: '10px',
+                  height: '10px',
+                  left: 0,
+                  right: 0,
+                  bottom: -5,
+                  background: 'inherit',
+                  transform: 'rotate(45deg)',
+                  margin: 'auto',
+                }}
+              />
+            </Text>
+          </m.div>
+          <m.div
+            variants={{
+              hidden: { ...hidden, y: 5 },
+              visible,
             }}
-          />
-        </Text>
-        <div className="relative mx-auto flex h-[120px] w-[120px] items-center justify-center overflow-hidden">
-          <CharacterCanvas
-            width={300}
-            height={300}
-            type={getValues('emotion') === 'ANGER' ? 'mad' : 'sad'}
-            className="left-auto right-auto m-auto h-[150px] w-[150px] overflow-hidden"
-          />
-        </div>
-      </div>
+            className="relative mx-auto flex h-[120px] w-[120px] items-center justify-center overflow-hidden"
+          >
+            <CharacterCanvas
+              width={300}
+              height={300}
+              type={getValues('emotion') === 'ANGER' ? 'mad' : 'sad'}
+              className="left-auto right-auto m-auto h-[150px] w-[150px] translate-y-0 overflow-hidden"
+            />
+          </m.div>
+        </m.div>
+      </LazyMotion>
       <div className="flex flex-col gap-[25px]">
         <TextField
           fullWidth
@@ -71,7 +94,7 @@ function MonsterName() {
           label="이름"
           placeholder="퇴사몬의 이름을 지어주세요"
           helperText="2~6자로 입력해주세요"
-          error={!!errors.monsterName}
+          error={!!monsterNameError}
           {...register('monsterName', {
             required: true,
             minLength: 2,
@@ -81,15 +104,11 @@ function MonsterName() {
 
         <TextField
           id="story"
+          className="bg-[#70737C]/12 h-28"
+          value={getValues('story')}
           fullWidth
           multiline
           readOnly
-          className="bg-[#70737C]/12 h-28"
-          error={!!errors.story}
-          {...register('story', {
-            required: true,
-            maxLength: 500,
-          })}
         />
       </div>
     </>

--- a/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/SelectEmotion.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { ChangeEventHandler, useEffect } from 'react';
+import { ChangeEventHandler, useEffect, useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import { cva } from 'class-variance-authority';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 import FormControlLabel from '@components/common/FormControlLabel';
 import Tooltip from '@components/common/Tooltip';
 
 import cn from '@utils/cn';
+
+import { visible, hidden } from '@constant/animation';
 
 import { EMOTION, DECORATION_TYPE } from '@api/schema/monster';
 
@@ -77,24 +80,30 @@ function SelectEmotion() {
   const {
     control,
     setValue,
-    formState: { errors },
+    formState: { errors, dirtyFields },
   } = useFormContext<UserInfo>();
 
   const selectedId = useWatch({ control, name: 'emotion' });
+
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setBtnDisabled(!!errors.emotion || selectedId === '');
   }, [selectedId, errors]);
 
-  // 감정별 기본 배경 색상 지정
   useEffect(() => {
     if (selectedId) setValue('decorations', [DEFAULT_BG[selectedId]]);
   }, [selectedId]);
 
+  // 선택 이후 앞/뒤로가기 시 툴팁 미노출
+  useEffect(() => {
+    if (!dirtyFields.emotion) setOpen(true);
+  }, []);
+
   return (
     <fieldset className="flex h-[calc(100%+95px)] w-full flex-col">
       <Tooltip
-        open
+        open={open}
         label="나의 감정"
         content={`나의 감정 상태에 따라\n다른 형태의 퇴사몬이 등장해요`}
         className="mb-12"
@@ -103,45 +112,61 @@ function SelectEmotion() {
         <Tooltip.Content className="p-3" />
       </Tooltip>
 
-      <div
-        className={cn(
-          gridStyles({
-            row: 2,
-            column: 1,
-          }),
-          'w-full gap-16',
-        )}
-      >
-        {EMOTIONS.map(({ label, id, className }) => (
-          <Controller
-            key={id}
-            name="emotion"
-            control={control}
-            render={({ field: { onChange } }) => {
-              const handleChange: ChangeEventHandler = () => {
-                onChange(id);
-              };
+      <LazyMotion features={domAnimation}>
+        <div
+          className={cn(
+            gridStyles({
+              row: 2,
+              column: 1,
+            }),
+            'w-full gap-16',
+          )}
+        >
+          {EMOTIONS.map(({ label, id, className }) => (
+            <Controller
+              key={id}
+              name="emotion"
+              control={control}
+              render={({ field: { onChange } }) => {
+                const handleChange: ChangeEventHandler = () => {
+                  onChange(id);
+                  // 감정별 기본 배경 색상 지정
+                  setValue('decorations', [DEFAULT_BG[id]]);
+                };
 
-              return (
-                <FormControlLabel
-                  id={id}
-                  name="emotion"
-                  label={label}
-                  checked={selectedId === id}
-                  className={cn(buttonStyle(), className)}
-                  control={
-                    <input
-                      type="radio"
-                      className="a11yHidden"
-                      onChange={handleChange}
+                return (
+                  <m.div
+                    initial={open ? 'visible' : 'hidden'}
+                    animate="visible"
+                    variants={{
+                      hidden: { ...hidden, y: 10 },
+                      visible: {
+                        ...visible,
+                        transition: { duration: 0.3 },
+                      },
+                    }}
+                  >
+                    <FormControlLabel
+                      id={id}
+                      name="emotion"
+                      label={label}
+                      checked={selectedId === id}
+                      className={cn(buttonStyle(), className)}
+                      control={
+                        <input
+                          type="radio"
+                          className="a11yHidden"
+                          onChange={handleChange}
+                        />
+                      }
                     />
-                  }
-                />
-              );
-            }}
-          />
-        ))}
-      </div>
+                  </m.div>
+                );
+              }}
+            />
+          ))}
+        </div>
+      </LazyMotion>
     </fieldset>
   );
 }

--- a/src/app/(route)/(monster)/monster/produce/components/SelectStress.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/SelectStress.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
 import { match } from 'ts-pattern';
 
+import AnimatedNumber from '@components/AnimatedNumber';
+import Badge from '@components/common/Badge';
+import Text from '@components/common/Text';
 import FormHelperText from '@components/common/TextField/FormHelperText';
 import Tooltip from '@components/common/Tooltip';
 import Slider from '@components/Slider';
@@ -40,22 +43,33 @@ const helperText = (stress: number): string => {
 };
 
 function SelectStress() {
-  const { min, max, step } = slider;
   const { setBtnDisabled } = useMonsterLayout();
-  const { control, getValues } = useFormContext<UserInfo>();
+
+  const {
+    control,
+    getValues,
+    formState: { dirtyFields },
+  } = useFormContext<UserInfo>();
+
+  const [open, setOpen] = useState(false);
 
   const stress = useWatch({ control, name: 'stress' });
 
+  // 선택 이후 앞/뒤로가기 시 툴팁 미노출
   useEffect(() => {
-    setBtnDisabled(false);
+    if (!dirtyFields.stress) setOpen(true);
   }, []);
 
+  useEffect(() => {
+    setBtnDisabled(!dirtyFields.stress);
+  }, [stress]);
+
   return (
-    <div className="h-[calc(100%+95px)]">
+    <div className="flex h-full flex-col">
       <Tooltip
-        open
+        open={open}
         label="스트레스 정도"
-        content={`스트레스가 높을수록 퇴사몬을 \n 클리어하기 위해 더 많은 탭이 필요해요`}
+        content={`스트레스가 높을수록 퇴사몬을 \n클리어하기 위해 더 많은 탭이 필요해요`}
         className="mb-[26px]"
       >
         <Tooltip.Label className="flex-none" />
@@ -68,22 +82,26 @@ function SelectStress() {
         render={({ field: { onChange } }) => {
           return (
             <Slider
-              step={step}
               displayInterval
-              defaultValue={getValues('stress')}
+              value={getValues('stress')}
               onChange={onChange}
-              className="mb-48"
-              min={min}
-              max={max}
+              {...slider}
             />
           );
         }}
       />
-
-      <span className="m-auto flex h-[180px] w-[180px] flex-col items-center justify-center rounded-circular bg-[var(--color-base-cool-neutral-7)]">
-        <span className="display-1-bold text-white">{stress}</span>
-        <FormHelperText>{helperText(stress)}</FormHelperText>
-      </span>
+      {/* 스트레스 수치 텍스트 라벨 */}
+      <Badge
+        component="div"
+        variant="dot"
+        color="alternative"
+        className="m-auto h-[180px] w-[180px] flex-col"
+      >
+        <Text component="div" variant="display-1" weight="bold" color="strong">
+          <AnimatedNumber animateToNumber={stress} />
+        </Text>
+        <FormHelperText component="span">{helperText(stress)}</FormHelperText>
+      </Badge>
     </div>
   );
 }

--- a/src/app/(route)/(monster)/monster/produce/components/WriteStory.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/WriteStory.tsx
@@ -50,9 +50,11 @@ function WriteStory() {
     },
   } = useFormContext<UserInfo>();
 
+  const storyValue = useWatch({ control, name: 'story' });
+
   useEffect(() => {
-    setBtnDisabled(!!story);
-  }, [story]);
+    setBtnDisabled(!storyValue || !!story);
+  }, [storyValue]);
 
   return (
     <TextField

--- a/src/app/(route)/(monster)/monster/produce/components/layout/MonsterLayout.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/layout/MonsterLayout.tsx
@@ -1,10 +1,9 @@
 import { useState, type MouseEvent, type MouseEventHandler } from 'react';
 
-import { motion } from 'framer-motion';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 import Button from '@components/common/Button';
 import Text from '@components/common/Text';
-import FixedBottom from '@components/FixedBottom';
 
 import cn from '@utils/cn';
 import stringToElement from '@utils/string-to-element';
@@ -33,6 +32,7 @@ function MonsterLayout({
   const [callback, setCallback] = useState<Callback>(() => {
     return (e: MouseEvent) => {
       goNext(e);
+      setBtnDisabled(true);
     };
   });
 
@@ -49,15 +49,15 @@ function MonsterLayout({
   const buttonLabels = control || ['이전으로', '다음으로'];
 
   return (
-    <>
-      <div
-        className={cn(
-          'flex h-full w-full flex-1 flex-col justify-between bg-black p-20 pt-[58px]',
-          className,
-        )}
-      >
-        <motion.p
-          className={cn('touch-auto', 'pb-32', {
+    <div
+      className={cn(
+        'flex h-full w-full flex-1 flex-col justify-between bg-black p-20 pt-[58px]',
+        className,
+      )}
+    >
+      <LazyMotion features={domAnimation}>
+        <m.p
+          className={cn('touch-auto select-none', 'pb-32', {
             hidden: !title,
           })}
           initial="hidden"
@@ -75,14 +75,13 @@ function MonsterLayout({
           >
             {title && stringToElement(title)}
           </Text>
-        </motion.p>
+        </m.p>
+      </LazyMotion>
 
-        <MonsterLayoutProvider value={{ setBtnDisabled, registerCallback }}>
-          {children}
-        </MonsterLayoutProvider>
-      </div>
-
-      <FixedBottom className="left-1/2 flex max-w-[375px] -translate-x-1/2 touch-none gap-8 py-5">
+      <MonsterLayoutProvider value={{ setBtnDisabled, registerCallback }}>
+        {children}
+      </MonsterLayoutProvider>
+      <nav className="left-1/2 flex max-w-[375px] touch-none gap-8">
         <Button
           className={cn('flex-1', { hidden: control?.length === 1 })}
           size="medium"
@@ -103,8 +102,8 @@ function MonsterLayout({
             {buttonLabels[buttonLabels.length - 1]}
           </Text>
         </Button>
-      </FixedBottom>
-    </>
+      </nav>
+    </div>
   );
 }
 

--- a/src/app/(route)/(monster)/monster/produce/page.tsx
+++ b/src/app/(route)/(monster)/monster/produce/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import DotsPagination from '@components/DotsPagination';
 import ScreenView from '@components/logging/ScreenView';
 
@@ -24,12 +26,20 @@ function MonsterProducePage() {
     'emotion',
   );
 
+  const [dir, setDir] = useState(1);
+
+  const setStepAndDirection = (nextStep: typeof step, nextDir: 1 | -1 = 1) => {
+    setDir(nextDir);
+    setStep(nextStep);
+  };
+
   return (
     <MonsterInfoProvider>
       <DotsPagination
         activeId={step}
         className="absolute right-0 ml-auto mt-[28px] w-full px-20"
         orderItems={funnel.map((id) => ({ id }))}
+        dir={Math.sign(dir) ? 'forward' : 'backward'}
       />
 
       <Funnel>
@@ -38,7 +48,7 @@ function MonsterProducePage() {
           <MonsterLayout
             title={title.emotion}
             control={['다음으로']}
-            goNext={() => setStep('stress')}
+            goNext={() => setStepAndDirection('stress')}
           >
             <ScreenView name="make_1">
               <SelectEmotion />
@@ -50,8 +60,8 @@ function MonsterProducePage() {
         <Funnel.Step name="stress">
           <MonsterLayout
             title={title.stress}
-            goPrev={() => setStep('emotion')}
-            goNext={() => setStep('story')}
+            goPrev={() => setStepAndDirection('emotion', -1)}
+            goNext={() => setStepAndDirection('story')}
           >
             <ScreenView name="make_2">
               <SelectStress />
@@ -63,8 +73,8 @@ function MonsterProducePage() {
         <Funnel.Step name="story">
           <MonsterLayout
             title={title.story}
-            goPrev={() => setStep('stress')}
-            goNext={() => setStep('monstername')}
+            goPrev={() => setStepAndDirection('stress', -1)}
+            goNext={() => setStepAndDirection('monstername')}
           >
             <ScreenView name="make_3">
               <WriteStory />
@@ -75,9 +85,9 @@ function MonsterProducePage() {
         {/* 몬스터 닉네임 설정 */}
         <Funnel.Step name="monstername">
           <MonsterLayout
-            className=" from-29% to-78% bg-gradient-to-b from-[#0F0F10] to-[#253047]"
-            goPrev={() => setStep('story')}
-            goNext={() => setStep('monsterstyle')}
+            className="bg-gradient"
+            goPrev={() => setStepAndDirection('story', -1)}
+            goNext={() => setStepAndDirection('monsterstyle')}
           >
             <ScreenView name="make_4">
               <MonsterName />
@@ -88,8 +98,8 @@ function MonsterProducePage() {
         {/* 몬스터 스타일 설정 */}
         <Funnel.Step name="monsterstyle">
           <MonsterLayout
-            className=" from-29% to-78% bg-gradient-to-b from-[#0F0F10] to-[#253047]"
-            goPrev={() => setStep('monstername')}
+            className="bg-gradient"
+            goPrev={() => setStepAndDirection('monstername', -1)}
             goNext={() => {}}
           >
             <ScreenView name="make_5">

--- a/src/app/components/AnimatedNumber/index.tsx
+++ b/src/app/components/AnimatedNumber/index.tsx
@@ -1,0 +1,100 @@
+import { ComponentPropsWithoutRef, useEffect, useRef, useState } from 'react';
+
+import { motion, useAnimation, useInView } from 'framer-motion';
+
+import cn from '@utils/cn';
+
+const NUMBERS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+type AnimatedNumberProps = ComponentPropsWithoutRef<'div'> & {
+  animateToNumber: number;
+};
+
+function AnimatedNumber({ className, animateToNumber }: AnimatedNumberProps) {
+  const ref = useRef(null);
+  const keyCount = useRef(0);
+  const numericRecRef = useRef<HTMLSpanElement>(null);
+
+  const controls = useAnimation();
+  const isInView = useInView(ref, { once: true });
+
+  const [numberWidth, setNumberWidth] = useState(0);
+  const [numberHeight, setNumberHeight] = useState(0);
+
+  const animateToNumbersArr = Array.from(
+    String(Math.abs(animateToNumber)),
+    Number,
+  );
+
+  useEffect(() => {
+    if (numericRecRef.current) {
+      const { width, height } = numericRecRef.current.getBoundingClientRect();
+
+      setNumberHeight(height);
+      setNumberWidth(width);
+    }
+
+    return () => {
+      setNumberHeight(0);
+      setNumberWidth(0);
+    };
+  }, [animateToNumber]);
+
+  useEffect(() => {
+    if (isInView) {
+      controls.start('visible');
+    }
+  }, [isInView, animateToNumber]);
+
+  return (
+    <div ref={ref}>
+      {numberHeight !== 0 && (
+        <div className={cn('flex overflow-hidden', className)}>
+          {animateToNumbersArr.map((n, index) => (
+            <div
+              key={`an_${n}`}
+              style={{ height: numberHeight, width: numberWidth }}
+            >
+              {NUMBERS.map((number) => {
+                const destY = -1 * (numberHeight * animateToNumbersArr[index]);
+
+                keyCount.current += 1;
+
+                return (
+                  <motion.div
+                    className="tabular-nums"
+                    key={`${keyCount.current}`}
+                    initial="hidden"
+                    variants={{
+                      hidden: {
+                        y: 0,
+                      },
+                      visible: {
+                        y: destY,
+                      },
+                    }}
+                    animate={controls}
+                    transition={{
+                      type: 'tween',
+                      delay: index * 0.2,
+                    }}
+                  >
+                    {number}
+                  </motion.div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+      <span
+        ref={numericRecRef}
+        className="fixed -top-full tabular-nums opacity-0"
+      >
+        0
+      </span>
+    </div>
+  );
+}
+
+export default AnimatedNumber;

--- a/src/app/components/Slider.tsx
+++ b/src/app/components/Slider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, ComponentPropsWithRef, useState } from 'react';
+import { ComponentPropsWithRef } from 'react';
 
 import cn from '@utils/cn';
 
@@ -10,7 +10,7 @@ interface Props extends ComponentPropsWithRef<'input'> {
   max: number;
   min: number;
   step: number;
-  defaultValue?: number;
+  value: number;
   color?: string;
   displayInterval?: boolean;
 }
@@ -22,19 +22,10 @@ function Slider({
   color,
   onChange,
   className,
-  defaultValue = 0,
+  value,
   displayInterval = false,
   ...restProps
 }: Props) {
-  const [value, setValue] = useState(defaultValue || min);
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { target } = e;
-    setValue(Number(target.value));
-
-    onChange?.(e);
-  };
-
   const calculateBackground = () => {
     const percentage = ((value - min) / (max - min)) * 100;
     return `linear-gradient(90deg, ${color || 'var(--color-brand-primary-base)'} ${percentage}%, #70737C38 ${percentage}%)`;
@@ -53,7 +44,7 @@ function Slider({
           max={max}
           type="range"
           value={value}
-          onChange={handleChange}
+          onChange={onChange}
           style={{ background: calculateBackground() }}
           className={cn(
             'absolute top-0 h-12 w-full translate-y-1/2 appearance-none rounded-circular outline-none',

--- a/src/app/components/Slider.tsx
+++ b/src/app/components/Slider.tsx
@@ -4,6 +4,8 @@ import { ChangeEvent, ComponentPropsWithRef, useState } from 'react';
 
 import cn from '@utils/cn';
 
+import Text from './common/Text';
+
 interface Props extends ComponentPropsWithRef<'input'> {
   max: number;
   min: number;
@@ -55,24 +57,33 @@ function Slider({
           style={{ background: calculateBackground() }}
           className={cn(
             'absolute top-0 h-12 w-full translate-y-1/2 appearance-none rounded-circular outline-none',
-            'webkit-slider:h-48 webkit-slider:w-48 webkit-slider:appearance-none webkit-slider:rounded-circular webkit-slider:bg-[var(--color-brand-primary-base)] webkit-slider:shadow-0',
-            'moz-slider:h-48 moz-slider:w-48 moz-slider:appearance-none moz-slider:rounded-circular moz-slider:bg-[var(--color-brand-primary-base)] moz-slider:shadow-0',
-            'ms-slider:h-48 ms-slider:w-48 ms-slider:appearance-none ms-slider:rounded-circular ms-slider:bg-[var(--color-brand-primary-base)] ms-slider:shadow-0',
+            // 이후 autoprefixer 적용 개선
+            // webkit
+            'webkit-slider:h-40 webkit-slider:w-40 webkit-slider:appearance-none webkit-slider:rounded-circular webkit-slider:bg-[var(--color-brand-primary-base)] webkit-slider:shadow-0',
+            // moz
+            'moz-slider:h-40 moz-slider:w-40 moz-slider:appearance-none moz-slider:rounded-circular moz-slider:bg-[var(--color-brand-primary-base)] moz-slider:shadow-0',
+            // ms
+            'ms-slider:h-40 ms-slider:w-40 ms-slider:appearance-none ms-slider:rounded-circular ms-slider:bg-[var(--color-brand-primary-base)] ms-slider:shadow-0',
           )}
           {...restProps}
         />
       </div>
 
       {displayInterval && (
-        <ul className="label-2-regular flex w-full justify-between  text-[var(--color-base-cool-neutral-80-a)]">
+        <ul className="grid w-full grid-cols-11	grid-rows-1 justify-between text-center">
           {Array(11)
             .fill(1)
             .map((interval, idx) => {
-              const key = interval * idx * 10;
+              const stepVal = interval * idx * 10;
               return (
-                <li key={key}>
-                  <span>{idx === 0 ? interval : interval * idx * 10}</span>
-                </li>
+                <Text
+                  component="li"
+                  key={stepVal}
+                  variant="label-2"
+                  color="alternative"
+                >
+                  {idx === 0 ? interval : stepVal}
+                </Text>
               );
             })}
         </ul>

--- a/src/app/components/common/Badge/index.tsx
+++ b/src/app/components/common/Badge/index.tsx
@@ -1,34 +1,47 @@
-import { cloneElement, forwardRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 import { cva, VariantProps } from 'class-variance-authority';
 
 import cn from '@utils/cn';
 
-const badgeBoxStyles = cva('', {
-  variants: {
-    variant: {
-      dot: ['relative', 'w-max'],
-      standard: [],
-      string: [],
-    },
-  },
-  compoundVariants: [
-    {
-      variant: ['standard', 'string'],
-      className: ['flex', 'gap-8', 'items-center'],
-    },
+const badgeBoxStyles = cva(
+  [
+    'flex',
+    'items-center',
+    'justify-center',
+    'aspect-square',
+    'rounded-circular',
+    'text-center',
   ],
-  defaultVariants: {
-    variant: 'string',
+  {
+    variants: {
+      variant: {
+        dot: ['relative', 'w-max'],
+        standard: [],
+        string: [],
+      },
+      color: {
+        primary: ['bg-[--color-brand-primary-base]', 'text-black'],
+        alternative: ['bg-cool-neutral-7'],
+        inverse: ['bg-[--color-text-inverse]', 'text-black'],
+      },
+    },
+    compoundVariants: [
+      {
+        variant: ['standard', 'string'],
+        className: ['flex', 'gap-8', 'items-center'],
+      },
+    ],
+    defaultVariants: {
+      variant: 'string',
+    },
   },
-});
+);
 
 export const badgeStyles = cva('truncate', {
   variants: {
     variant: {
       dot: [
-        'max-w-8',
-        'h-8',
         'absolute',
         'right-0',
         'top-0',
@@ -49,6 +62,7 @@ export const badgeStyles = cva('truncate', {
     },
     color: {
       primary: ['bg-[--color-brand-primary-base]', 'text-black'],
+      alternative: ['bg-cool-neutral-7'],
       inverse: ['bg-[--color-text-inverse]', 'text-black'],
     },
     size: {
@@ -83,7 +97,6 @@ export type BadgeProps<T extends React.ElementType = 'span'> =
   React.ComponentPropsWithRef<T> &
     VariantProps<typeof badgeStyles> & {
       component?: T;
-      children?: [ReactNode, ...(readonly ReactNode[])];
       max?: number;
       count: number;
       showZero?: boolean;
@@ -113,12 +126,10 @@ const Badge = forwardRef(
     return (
       <Component
         ref={ref}
-        className={cn(badgeBoxStyles({ variant }), className)}
+        className={cn(badgeBoxStyles({ variant, color }), className)}
         {...rest}
       >
-        {cloneElement(children, {
-          className: 'shrink-0',
-        })}
+        {children}
         <span className={badgeStyles({ variant, color })}>
           {variant !== 'dot' && (count > max ? `${max}+` : count)}
         </span>

--- a/src/app/components/common/Icon/index.tsx
+++ b/src/app/components/common/Icon/index.tsx
@@ -8,6 +8,7 @@ import CloseSVG from '@public/icons/close.svg';
 import DownloadSVG from '@public/icons/download.svg';
 import EditSVG from '@public/icons/edit.svg';
 import EllipsisSVG from '@public/icons/ellipsis.svg';
+import ErrorSVG from '@public/icons/error.svg';
 import HamburgerSVG from '@public/icons/hamburger.svg';
 import InfoSVG from '@public/icons/info.svg';
 import MessageSVG from '@public/icons/message.svg';
@@ -21,6 +22,7 @@ export const IconMap = {
   'arrow-back': ArrowBackSVG,
   download: DownloadSVG,
   edit: EditSVG,
+  error: ErrorSVG,
   ellipsis: EllipsisSVG,
   hamburger: HamburgerSVG,
   information: InfoSVG,
@@ -37,6 +39,7 @@ export const iconVariants = cva(
     variants: {
       size: {
         12: ['w-12', 'h-12', '[&>svg]:w-12'],
+        14: ['w-[14px]', 'h-[14px]', '[&>svg]:w-[14px'],
         16: ['w-16', 'h-16', '[&>svg]:w-16'],
         18: ['w-18', 'h-18', '[&>svg]:w-18'],
         20: ['w-20', 'h-20', '[&>svg]:w-20'],
@@ -86,7 +89,7 @@ export type IconProps<T extends React.ElementType = 'span'> =
       name?: keyof typeof IconMap;
     };
 
-const Icon = forwardRef(
+const Icon = forwardRef<HTMLElement, IconProps>(
   <T extends React.ElementType = 'span'>(
     {
       component,

--- a/src/app/components/common/TextField/FormHelperText.tsx
+++ b/src/app/components/common/TextField/FormHelperText.tsx
@@ -1,7 +1,5 @@
 import { cx } from 'class-variance-authority';
 
-import ErrorSVG from '@public/icons/error.svg';
-
 import Icon from '@components/common/Icon';
 import Text, { type TextProps } from '@components/common/Text';
 
@@ -30,11 +28,7 @@ export default function FormHelperText<T extends React.ElementType = 'p'>({
       {...(error ? { color: 'error' } : { color: 'alternative' })}
       {...rest}
     >
-      {error && (
-        <Icon size={20}>
-          <ErrorSVG width={14} height={14} />
-        </Icon>
-      )}
+      {error && <Icon name="error" size={14} />}
       {children}
     </Text>
   );

--- a/src/app/constant/animation.ts
+++ b/src/app/constant/animation.ts
@@ -1,6 +1,8 @@
+export const hidden = { opacity: 0 };
+
+export const visible = { opacity: 1, y: 0 };
+
 export const fadeIn = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-  },
+  hidden,
+  visible,
 };


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 :
- 관련 Figma : 

### ⚙️ Changes
- 페이지 
  - `DotPagination` 컴포넌트의 `dir` prop을 전달하여, 버튼의 방향에 맞는 애니메이션이 동작되도록 수정하였습니다.

- **감정 선택 스텝**
  - 감정 선택 이후, 뒤로가기 진입의 경우 툴팁이 노출되지않도록 수정하였습니다.
  
- **스트레스 수치 선택 스텝**
  - 위와 동일하게 뒤로가기 진입의 경우 툴팁이 노출되지않도록 수정하였습니다.
  - `AnimatedNumber` 컴포넌트 생성 및 적용하였습니다. 
  - displayInterval(input 수치 가이드라인)의 위치가 input slider 핸들과 싱크가 맞도록 CSS 수정하였습니다.

- **몬스터 이름 작성 스텝**
  - 하단 스트레스 상황 텍스트 필드의 경우, `readOnly`로 수정되어 hook form의 register 및 watch 로직을 제거하였습니다. 
    마찬가지로 버튼 disabled 설정 조건식에서 제거하였습니다. 
