### PR TITLE
🐛 fix: 몬스터 이름 생성시, 공백만 입력하는 경우 방지  #124

### DIFF
--- a/src/app/(route)/(monster)/monster/produce/components/MosterName.tsx
+++ b/src/app/(route)/(monster)/monster/produce/components/MosterName.tsx
@@ -96,9 +96,10 @@ function MonsterName() {
           helperText="2~6자로 입력해주세요"
           error={!!monsterNameError}
           {...register('monsterName', {
-            required: true,
-            minLength: 2,
-            maxLength: 6,
+            validate: (value) => {
+              const trimmed = value.trim();
+              return trimmed.length >= 2 && trimmed.length <= 6;
+            },
           })}
         />
 


### PR DESCRIPTION
### 📝 About PR 

- 관련 이슈 : #124 

### ⚙️ Changes

몬스터 생성 시, 공백만 입력하는 경우도 form validation 을 통과하는 이슈 발생
- 입력된 value 를 trim 메소드로 공백을 제거한 다음, 해당 값이 2이상 6이하의 길이인지 체크


