### PR TITLE
feat(mock): 백엔드 없는 데모용 mock 모드 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ─────────────────────────────────────────────────────────────
+# 데모(Mock) 모드
+#   true 이면 모든 API 응답을 src/mocks/ 픽스처로 대체하고
+#   자동 로그인된 데모 유저로 동작합니다. (백엔드 불필요)
+#   실서버 재연결 시 false 로 두거나 삭제하세요.
+# ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_USE_MOCK=true
+
+# 앱 자신의 URL (배포 도메인). 로컬은 http://localhost:3000
+NEXT_PUBLIC_DOMAIN_NAME=http://localhost:3000
+
+# 백엔드 API 주소. mock 모드에서는 실제로 호출되지 않으므로 아무 값이나 가능.
+# 실서버 재연결 시 이 값을 실제 API 도메인으로 지정하세요.
+NEXT_PUBLIC_API_DOMAIN_NAME=https://mock.invalid
+
+# 토큰 암복호화 시크릿 (32자 이상 권장). mock 모드에서는 미사용.
+AUTH_SECRET=change-me-to-a-32-character-secret
+
+# ─────────────────────────────────────────────────────────────
+# 실서버(카카오 로그인) 연동 시에만 필요 — mock 모드에서는 불필요
+# ─────────────────────────────────────────────────────────────
+KAKAO_CLIENT_ID=
+KAKAO_CALLBACK=
+NEXT_PUBLIC_KAKAO_JS_KEY=
+NEXT_PUBLIC_KAKAO_SHARE_TEMPLATE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ yarn-error.log*
 next-env.d.ts
 
 .env*
+!.env.example
 *storybook.log

--- a/README.md
+++ b/README.md
@@ -171,3 +171,19 @@ _‘퇴사하고 싶다’_
         </td>
     </tr>
 </table>
+
+## 🧪 데모 모드 (Mock)
+
+백엔드 서버와 도메인이 만료되어, 실서버 없이 프론트엔드만 데모하기 위한 mock 모드가 있습니다.
+`NEXT_PUBLIC_USE_MOCK=true` 이면 모든 API 응답을 `src/mocks/` 픽스처로 대체하고, 자동 로그인된
+데모 유저로 동작합니다.
+
+```
+NEXT_PUBLIC_USE_MOCK=true
+NEXT_PUBLIC_DOMAIN_NAME=<배포 URL>
+NEXT_PUBLIC_API_DOMAIN_NAME=https://mock.invalid   # 실제로 호출되지 않음
+AUTH_SECRET=<아무 32자 이상 문자열>
+```
+
+실서버 재연결은 `NEXT_PUBLIC_USE_MOCK` 를 끄고 `NEXT_PUBLIC_API_DOMAIN_NAME` 를 실제 서버로
+지정하면 됩니다 (코드 변경 없음).

--- a/docs/adr/0001-mock-demo-mode.md
+++ b/docs/adr/0001-mock-demo-mode.md
@@ -1,0 +1,56 @@
+# 0001. Mock demo mode (backend-less deploy)
+
+- 상태: 채택(Accepted)
+- 날짜: 2026-07-08
+
+## 배경 (Context)
+
+백엔드 서버와 도메인이 만료되어 모든 API 호출을 받아줄 서버가 없습니다. 프로젝트는
+종료되었지만, 프론트엔드 데모는 계속 띄워두고 싶고, 나중에 실서버를 다시 붙일 때
+아무것도 되돌리지 않아도 되게 하고 싶습니다.
+
+정적 호스팅(GitHub Pages / `next export`)은 배제했습니다. 이 앱은 미들웨어 기반 인증
+게이팅과 서버 route 핸들러(`/api/auth/[...auth]`, `/api/init`)에 의존하는데, 정적 export는
+이를 금지합니다. 그리고 그 부분이야말로 재연결 시 그대로 살려야 할 통합 지점입니다. Next를
+유지(자체 Vercel 계정)하면 이를 보존할 수 있습니다.
+
+## 결정 (Decision)
+
+단일 환경변수 `NEXT_PUBLIC_USE_MOCK` 를 도입해, 켜지면 앱이 전적으로 픽스처로 동작하도록
+합니다.
+
+- **`src/mocks/`** — `config.ts`(플래그), `fixtures.ts`(데모 유저·몬스터·메시지),
+  `adapter.ts`(URL→픽스처 라우트 테이블을 가진 axios adapter).
+- **`src/app/api/api.config.ts`** — 플래그가 켜지면 두 axios 인스턴스
+  (`baseInstance`, `apiInstance`)가 `mockAdapter` 를 사용합니다. 이 한 곳에서 클라이언트·SSR의
+  모든 데이터 트래픽(인증 세션, 몬스터, 메시지, 상호작용, 응원)을 가로채므로 개별 엔드포인트
+  파일은 손대지 않습니다.
+- **`src/middleware.ts`** — 플래그가 켜지면 미들웨어 체인 전체를 우회합니다
+  (`NextResponse.next()`). 인증/몬스터 미들웨어는 토큰 갱신과 라우트 게이팅을 위해 백엔드를
+  호출하는데(일부는 axios가 아닌 raw `fetch`), 체인을 건너뛰면 죽은 호출을 막고 모든 페이지가
+  로그인된 데모 유저로 렌더됩니다.
+
+쓰기 요청(몬스터 생성·수정, 메시지 전송·확인)은 성공 응답만 돌려주며 저장되지 않습니다. 배포
+대상은 원 소유자의 Vercel이 아니라 자체 무료 Vercel 프로젝트입니다.
+
+## 결과 (Consequences)
+
+- 데모는 백엔드 없이, 실제 인증 없이 동작합니다. 읽기는 픽스처를 보여주고 쓰기는 no-op입니다.
+- **실서버 재연결:** `NEXT_PUBLIC_USE_MOCK=false`(또는 삭제)로 두고
+  `NEXT_PUBLIC_API_DOMAIN_NAME` / `NEXT_PUBLIC_DOMAIN_NAME` 를 실서버로 지정하면 됩니다.
+  코드 변경은 없습니다 — 플래그가 꺼지면 adapter와 미들웨어 가드는 동작하지 않습니다.
+- **mock 모드 완전 제거:** `src/mocks/` 삭제, `api.config.ts` 의 두 줄 가드, `src/middleware.ts`
+  의 가드만 지우면 됩니다.
+- 픽스처는 시간이 지나면 실제 API 형태와 어긋날 수 있습니다. 동일한 `@api` 인터페이스로
+  타입을 맞춰 두어, 명백한 불일치는 빌드 시점에 잡히게 했습니다.
+
+## 데모 배포에 필요한 환경변수
+
+```
+NEXT_PUBLIC_USE_MOCK=true
+NEXT_PUBLIC_DOMAIN_NAME=<Vercel URL, 예: https://salpinoff-fe-henna.vercel.app>
+NEXT_PUBLIC_API_DOMAIN_NAME=https://mock.invalid   # 어떤 값이든 무방, 실제로 호출되지 않음
+AUTH_SECRET=<32자 이상 임의 문자열>                  # mock 모드에서는 미사용, 빌드용
+```
+
+전체 목록은 [`.env.example`](../../.env.example) 참고.

--- a/src/app/api/api.config.ts
+++ b/src/app/api/api.config.ts
@@ -2,6 +2,9 @@ import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
 import { getQueryClient } from '@utils/query/get-query-client';
 
+import mockAdapter from 'src/mocks/adapter';
+import { USE_MOCK } from 'src/mocks/config';
+
 import { API_URLS } from './api.constants';
 import AuthFactory from './auth/query';
 import { Session } from './schema/token';
@@ -14,6 +17,8 @@ const createInstance = (baseURL: string) => {
     headers: {
       'Content-Type': 'application/json',
     },
+    // Demo mode: answer every request from fixtures instead of the (expired) backend.
+    ...(USE_MOCK ? { adapter: mockAdapter } : {}),
   });
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,10 @@
+import { type NextMiddleware, NextResponse } from 'next/server';
+
 import chain from './app/middlewares/chain';
 import withAuthentification from './app/middlewares/factory/withAuthentication';
 import withMonsterHandler from './app/middlewares/factory/withMonsterHandler';
 import withSignUpHandle from './app/middlewares/factory/withSignUpHandle';
+import { USE_MOCK } from './mocks/config';
 
 const middlewares = [
   withAuthentification,
@@ -9,7 +12,14 @@ const middlewares = [
   withMonsterHandler,
 ];
 
-export default chain(middlewares);
+// Demo mode: the auth/monster middlewares all hit the (expired) backend to
+// refresh tokens and gate routes. Skip the whole chain so every page renders as
+// the signed-in demo user. Reconnect by unsetting NEXT_PUBLIC_USE_MOCK.
+const middleware: NextMiddleware = USE_MOCK
+  ? () => NextResponse.next()
+  : chain(middlewares);
+
+export default middleware;
 
 export const config = {
   matcher: [

--- a/src/mocks/adapter.ts
+++ b/src/mocks/adapter.ts
@@ -1,0 +1,160 @@
+import type { AxiosAdapter, AxiosResponse } from 'axios';
+
+import {
+  DEMO_MESSAGES,
+  DEMO_MONSTERS,
+  DEMO_SESSION,
+  DEMO_USER,
+  findMonster,
+} from './fixtures';
+
+// Intercepts every request on both axios instances and answers from fixtures.
+// Route table is matched top-to-bottom, so more specific paths come first.
+// `config.url` is the path relative to the instance baseURL (e.g. "/monsters/my").
+
+type Ctx = {
+  match: RegExpExecArray | null;
+  body: Record<string, unknown>;
+};
+
+type Route = {
+  method: 'get' | 'post' | 'put' | 'delete' | 'all';
+  test: RegExp;
+  data: (ctx: Ctx) => unknown;
+};
+
+const routes: Route[] = [
+  // --- baseInstance: Next auth / init route handlers ---
+  { method: 'all', test: /^\/api\/auth\/session$/, data: () => DEMO_SESSION },
+  {
+    method: 'all',
+    test: /^\/api\/auth\/csrf$/,
+    data: () => ({ csrfToken: 'demo-csrf' }),
+  },
+  { method: 'all', test: /^\/api\/auth\/signout$/, data: () => ({}) },
+  {
+    method: 'all',
+    test: /^\/api\/auth\/signin\/kakao$/,
+    data: () => ({ url: `${process.env.NEXT_PUBLIC_DOMAIN_NAME}/` }),
+  },
+  { method: 'all', test: /^\/api\/init$/, data: () => ({ status: 200 }) },
+
+  // --- members ---
+  { method: 'all', test: /^\/members\/my$/, data: () => ({}) },
+  {
+    method: 'all',
+    test: /^\/members\/token\/refresh$/,
+    data: () => ({ accessToken: DEMO_SESSION.accessToken }),
+  },
+  {
+    method: 'all',
+    test: /^\/members\/login\/kakao$/,
+    data: () => ({
+      memberId: DEMO_USER.memberId,
+      accessToken: DEMO_SESSION.accessToken,
+      refreshToken: 'demo-refresh-token',
+      username: DEMO_USER.username,
+      code: 102,
+    }),
+  },
+  { method: 'all', test: /^\/members\/logout$/, data: () => ({}) },
+
+  // --- monsters (specific paths before /monsters/:id) ---
+  {
+    method: 'get',
+    test: /^\/monsters\/my\/rep$/,
+    data: () => DEMO_MONSTERS[0],
+  },
+  {
+    method: 'get',
+    test: /^\/monsters\/my$/,
+    data: () => ({
+      page: 0,
+      size: 10,
+      content: DEMO_MONSTERS,
+      totalElements: DEMO_MONSTERS.length,
+    }),
+  },
+  {
+    method: 'post',
+    test: /^\/monsters$/,
+    data: ({ body }) => ({
+      ...DEMO_MONSTERS[0],
+      ...body,
+      monsterId: '1',
+      ownerName: DEMO_USER.username,
+      interactionCount: 10,
+      currentInteractionCount: 0,
+      monsterDecorations: (
+        (body.monsterDecorations as unknown[] | undefined) ?? []
+      ).map((d, i) => ({ decorationId: i + 1, ...(d as object) })),
+    }),
+  },
+  // confirm message (POST /monsters/:id/messages/:messageId)
+  {
+    method: 'post',
+    test: /^\/monsters\/[^/]+\/messages\/[^/]+$/,
+    data: () => ({}),
+  },
+  {
+    method: 'get',
+    test: /^\/monsters\/[^/]+\/messages$/,
+    data: () => DEMO_MESSAGES,
+  },
+  {
+    method: 'post',
+    test: /^\/monsters\/([^/]+)\/interactions$/,
+    data: ({ match, body }) => ({
+      monsterId: match?.[1] ?? '1',
+      currentInteractionCount: String(body.interactionCount ?? 0),
+    }),
+  },
+  {
+    method: 'all',
+    test: /^\/monsters\/[^/]+\/encouragement$/,
+    data: () => ({}),
+  },
+  {
+    method: 'get',
+    test: /^\/monsters\/([^/]+)$/,
+    data: ({ match }) => findMonster(match?.[1]),
+  },
+  { method: 'put', test: /^\/monsters\/[^/]+$/, data: () => ({}) },
+  { method: 'delete', test: /^\/monsters\/[^/]+$/, data: () => ({}) },
+];
+
+const parseBody = (raw: unknown): Record<string, unknown> => {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return (raw as Record<string, unknown>) ?? {};
+};
+
+const mockAdapter: AxiosAdapter = async (config) => {
+  const method = (config.method ?? 'get').toLowerCase();
+  const path = (config.url ?? '').split('?')[0];
+  const body = parseBody(config.data);
+
+  const route = routes.find(
+    (r) => (r.method === 'all' || r.method === method) && r.test.test(path),
+  );
+
+  if (!route && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(`[mock] unmatched ${method.toUpperCase()} ${path} -> {}`);
+  }
+
+  return {
+    data: route ? route.data({ match: route.test.exec(path), body }) : {},
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config,
+  } as AxiosResponse;
+};
+
+export default mockAdapter;

--- a/src/mocks/config.ts
+++ b/src/mocks/config.ts
@@ -1,0 +1,5 @@
+// ponytail: single switch for demo mock mode. Set NEXT_PUBLIC_USE_MOCK=true to
+// serve the app entirely from fixtures (backend/domain are expired). Unset it and
+// point NEXT_PUBLIC_API_DOMAIN_NAME at a real server to reconnect — no code changes.
+// See docs/adr/0001-mock-demo-mode.md
+export const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === 'true';

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,0 +1,95 @@
+import type { MessageListResponse } from '@api/message/type';
+import type {
+  CreateMonsterResponse,
+  MonsterResponse,
+} from '@api/monster/types';
+import { DECORATION_TYPE, EMOTION } from '@api/schema/monster';
+import type { Session } from '@api/schema/token';
+
+// Canned demo data. Reads only — writes echo back through the adapter and are not
+// persisted (see docs/adr/0001-mock-demo-mode.md).
+
+export const DEMO_USER = { memberId: 1, username: '데모몬' };
+
+export const DEMO_SESSION: Session = {
+  accessToken: 'demo-access-token',
+  status: 'authenticated',
+  userInfo: { memberId: DEMO_USER.memberId, username: DEMO_USER.username },
+};
+
+const deco = (
+  decorationId: number,
+  decorationType: keyof typeof DECORATION_TYPE,
+  decorationValue: string,
+) => ({ decorationId, decorationType, decorationValue });
+
+export const DEMO_MONSTERS: CreateMonsterResponse[] = [
+  {
+    monsterId: '1',
+    monsterName: '부글이',
+    emotion: EMOTION.ANGER,
+    content:
+      '오늘 회의에서 준비한 걸 다 못 보여줘서 분했어. 그래도 다음엔 잘할 거야!',
+    rating: 3,
+    ratingRange: '20~40',
+    interactionCount: 10,
+    currentInteractionCount: 7,
+    interactionCountPerEncouragement: 5,
+    createdAt: '2024-05-01T09:00:00',
+    ownerName: DEMO_USER.username,
+    monsterDecorations: [
+      deco(1, DECORATION_TYPE.BACKGROUND_COLOR, '#F450A6'),
+      deco(2, DECORATION_TYPE.CAP, 'HEADSET'),
+      deco(3, DECORATION_TYPE.ACCESSORY, 'COFFEE'),
+    ],
+  },
+  {
+    monsterId: '2',
+    monsterName: '축축이',
+    emotion: EMOTION.DEPRESSION,
+    content: '요즘 뭘 해도 기운이 안 나. 잠깐 쉬어가도 괜찮겠지?',
+    rating: 2,
+    ratingRange: '0~20',
+    interactionCount: 8,
+    currentInteractionCount: 8,
+    interactionCountPerEncouragement: 4,
+    createdAt: '2024-05-03T18:30:00',
+    ownerName: DEMO_USER.username,
+    monsterDecorations: [
+      deco(4, DECORATION_TYPE.BACKGROUND_COLOR, '#4485FD'),
+      deco(5, DECORATION_TYPE.FACE, 'GLASSES'),
+      deco(6, DECORATION_TYPE.ACCESSORY, 'LAPTOP'),
+    ],
+  },
+];
+
+export const findMonster = (monsterId?: string): MonsterResponse =>
+  DEMO_MONSTERS.find((m) => m.monsterId === monsterId) ?? DEMO_MONSTERS[0];
+
+export const DEMO_MESSAGES: MessageListResponse = {
+  content: [
+    {
+      messageId: 1,
+      sender: '친구 A',
+      content: '오늘도 수고 많았어! 넌 충분히 잘하고 있어.',
+      checked: false,
+    },
+    {
+      messageId: 2,
+      sender: '동료 B',
+      content: '그 발표 진짜 멋졌어. 자신감 가져도 돼!',
+      checked: false,
+    },
+    {
+      messageId: 3,
+      sender: '가족',
+      content: '언제나 응원해. 오늘은 푹 쉬어.',
+      checked: true,
+    },
+  ],
+  size: 10,
+  page: 0,
+  totalElements: 3,
+  checkedMessageCount: 1,
+  uncheckedMessageCount: 2,
+};


### PR DESCRIPTION
## 배경
백엔드 서버 + 도메인이 만료되어 API를 받아줄 서버가 없음. 실서버 없이 프론트만 데모하고, 나중에 실서버를 언제든 재연결할 수 있어야 함.

정적 export(GitHub Pages)는 미들웨어/route 핸들러를 걷어내야 해서 재연결에 불리 → 자체 Vercel + env 플래그 mock 방식 채택. (`docs/adr/0001-mock-demo-mode.md`)

## 변경
- **`src/mocks/`** — `config.ts`(플래그), `fixtures.ts`(데모 유저·몬스터·메시지), `adapter.ts`(URL→픽스처 axios adapter)
- **`api.config.ts`** — 플래그 시 `baseInstance`/`apiInstance`에 `mockAdapter` 적용 → 모든 데이터 트래픽 가로챔 (엔드포인트 파일 무수정)
- **`middleware.ts`** — 플래그 시 미들웨어 체인 전체 우회 (auth/monster 미들웨어의 죽은 백엔드 호출 차단, 자동 로그인)
- 문서: `docs/adr/0001-mock-demo-mode.md`, `.env.example`, `README` 데모 모드 섹션

## 동작 (`NEXT_PUBLIC_USE_MOCK=true`)
- 자동 로그인된 데모 유저, 모든 읽기는 픽스처
- 쓰기(생성/수정/전송)는 성공 응답만 (미저장)

## 재연결
`NEXT_PUBLIC_USE_MOCK` 끄고 `NEXT_PUBLIC_API_DOMAIN_NAME`를 실서버로 → 코드 변경 0

## 검증
- `npm run build` ✅
- `PORT=3100 npm start` → `/`, `/onboarding`, `/monster/produce`, `/monster/:id/result`, `/share`, `/signin`, `/profile/edit` 전부 200 (기존 `/`는 500이었음). 홈에 대표몬 '부글이' + 데모유저 렌더 확인.